### PR TITLE
Generate lead users chats dynamically

### DIFF
--- a/src/mocks/createUsers.ts
+++ b/src/mocks/createUsers.ts
@@ -90,7 +90,7 @@ export const createLeadUser = (numChats: number): Partial<User> => {
 
   return {
     id: 1,
-    name: "John Doe",
+    name: "ThePrimegean",
     chats,
     has_profile: true,
   };

--- a/src/mocks/createUsers.ts
+++ b/src/mocks/createUsers.ts
@@ -1,0 +1,97 @@
+import {User, Chat} from "../types/types";
+
+// Array of possible user names
+const possibleNames = [
+  "Alice",
+  "Bob",
+  "Charlie",
+  "David",
+  "Eve",
+  "Frank",
+  "Grace",
+  "Hannah",
+  "Ivy",
+  "Jack",
+  // Add more names as needed
+];
+
+// Generate a random name from the list
+const getRandomName = () => {
+  return possibleNames[Math.floor(Math.random() * possibleNames.length)];
+};
+
+// Generates a list of users for a chat, ensuring the lead user and agreed_users are included
+const generateUsersForChat = (
+  leadUserId: number,
+  agreedUsers: number[],
+  totalUsers: number,
+): User[] => {
+  const allUsers: User[] = [];
+
+  // Ensure lead user is included first with "lead" status
+  allUsers.push({
+    id: leadUserId,
+    name: "ThePrimegean",
+    status: "lead",
+    users: [],
+    words: [],
+    has_profile: true,
+    telephoneNumber: "",
+    chats: [],
+  });
+
+  // Ensure agreed_users are included with "invitee" status
+  agreedUsers.forEach(id => {
+    if (id !== leadUserId) {
+      // Avoid adding the lead user again
+      allUsers.push({
+        id,
+        name: `User ${id}`,
+        status: "invitee",
+        users: [],
+        words: [],
+        has_profile: true,
+        telephoneNumber: "",
+        chats: [],
+      });
+    }
+  });
+  // Add additional users to meet the total user count if needed
+  while (allUsers.length < totalUsers) {
+    const id = allUsers.length + 1;
+    const name = getRandomName();
+    allUsers.push({
+      id,
+      name,
+      status: "invitee",
+      users: [],
+      words: [],
+      has_profile: true,
+      telephoneNumber: "",
+      chats: [],
+    });
+  }
+
+  return allUsers;
+};
+
+export const createLeadUser = (numChats: number): Partial<User> => {
+  const statuses = ["pending", "sold", "declined"];
+
+  const chats: Chat[] = Array.from({length: numChats}, (_, i) => ({
+    lead_id: 1,
+    agreed_users: [1, 2, 3],
+    name: `Chat ${i + 1}`,
+    id: i + 1,
+    status: statuses[i % statuses.length], // Rotate statuses
+    words: (i + 1) * 10,
+    users: generateUsersForChat(1, [2, 3], 5),
+  }));
+
+  return {
+    id: 1,
+    name: "John Doe",
+    chats,
+    has_profile: true,
+  };
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import {http, HttpResponse} from "msw";
 import {User} from "../types/types";
+import {createLeadUser} from "./createUsers";
 
 interface GetUserRequestBody {
   userId: number;
@@ -10,21 +11,27 @@ const backendUrl =
   import.meta.env.VITE_BACKEND_URL ||
   "https://daniilbot-k9qlu.ondigitalocean.app";
 
-const leadUser: Partial<User> = {
-  id: 1,
-  name: "John Doe",
-  chats: [
-    {
-      lead_id: 1,
-      agreed_users: [2, 3],
-      name: "Chat with Team",
-      id: 1,
-      status: "active",
-      words: 120,
-      users: [],
-    },
-  ],
-  has_profile: true,
+// const leadUser: Partial<User> = {
+//   id: 1,
+//   name: "John Doe",
+//   chats: [
+//     {
+//       lead_id: 1,
+//       agreed_users: [2, 3],
+//       name: "Chat with Team",
+//       id: 1,
+//       status: "active",
+//       words: 120,
+//       users: [],
+//     },
+//   ],
+//   has_profile: true,
+// };
+
+// Function to dynamically create a lead user with a specified number of chats
+const getLeadUser = () => {
+  const numChats = parseInt(import.meta.env.VITE_NUM_CHATS || "1", 10);
+  return createLeadUser(numChats);
 };
 
 const newUser: Partial<User> = {
@@ -65,7 +72,7 @@ export const handlers = [
     const {userId} = body;
     switch (userId) {
       case 1:
-        return HttpResponse.json(leadUser);
+        return HttpResponse.json(getLeadUser());
       case 2:
         return HttpResponse.json(newUser);
       case 3:


### PR DESCRIPTION
I added a function, that create multiple chats for the lead user dynamically based on a variable set in the .env `VITE_NUM_CHATS` that you need to set by yourself, like this:

```
VITE_NUM_CHATS=5  # Set the number of chats for the selected user [atm implemetned only for the lead user]
```