### PR TITLE
slombard/cha 464 solve different chips showing same chats

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,18 +54,9 @@ const AppContent: React.FC = () => {
       console.log("App Entered event already tracked");
     }
 
-    if (!user.has_profile && user.chats.length > 0) {
-      console.log(
-        "User doesn't have a profile but has at least one chat, showing OnboardUserB modal",
-      );
-    } else if (user.has_profile) {
+    if (user.has_profile) {
       console.log("User has a profile, showing user's chats");
       setCurrentTab(tabs[1].id);
-    } else if (!user.has_profile && user.chats.length === 0) {
-      console.log(
-        "User doesn't have a profile and doesn't have any chats, he just opened the app",
-      );
-      setCurrentTab(tabs[0].id);
     }
   }, [eventBuilder, user.chats.length, user.has_profile, user.id]);
 

--- a/src/components/ChatTable.tsx
+++ b/src/components/ChatTable.tsx
@@ -20,9 +20,12 @@ const ChatTable: React.FC<ChatTableProps> = ({user, backendUrl}) => {
 
     const newSelectedChats = selectedValues.reduce(
       (acc, id) => {
-        const chat = user.chats.find(item => String(item.id) === id);
+        // const chat = user.chats.find(item => String(item.id) === id);
+        const chat = user.chatsToSellUnfolded?.find(
+          item => String(item.userId) === id,
+        );
         if (chat) {
-          const key = `(${String(chat.id)}, '${chat.name}')`;
+          const key = `(${String(chat.userId)}, '${chat.userName}')`;
           acc[key] = chat.words;
         }
         return acc;
@@ -35,7 +38,10 @@ const ChatTable: React.FC<ChatTableProps> = ({user, backendUrl}) => {
 
   const totalValue = selectedValues.reduce(
     (sum, id) =>
-      sum + (user.chats.find(item => String(item.id) === id)?.words || 0),
+      //   sum + (user.chats.find(item => String(item.id) === id)?.words || 0),
+      sum +
+      (user.chatsToSellUnfolded?.find(item => String(item.userId) === id)
+        ?.words || 0),
     0,
   );
 
@@ -43,21 +49,22 @@ const ChatTable: React.FC<ChatTableProps> = ({user, backendUrl}) => {
 
   return (
     <div className='text-left'>
-      {user.chats.map(item => (
+      {/* {user.chats.map(item => ( */}
+      {user.chatsToSellUnfolded?.map(item => (
         <Cell
-          key={item.id}
+          key={item.userId}
           Component='label'
           before={
             <Multiselectable
               name='multiselect'
-              value={String(item.id)}
-              checked={selectedValues.includes(String(item.id))}
-              onChange={() => handleSelectionChange(String(item.id))}
+              value={String(item.userId)}
+              checked={selectedValues.includes(String(item.userId))}
+              onChange={() => handleSelectionChange(String(item.userId))}
             />
           }
           multiline
         >
-          <strong>{item.words} Points </strong> - {item.name}
+          <strong>{item.words} Points </strong> - {item.userName}
         </Cell>
       ))}
       <table className='mt-5 w-full text-center'>

--- a/src/components/ChatTableUserB.tsx
+++ b/src/components/ChatTableUserB.tsx
@@ -30,6 +30,8 @@ const ChatTableUserB: React.FC<ChatTableUserBProps> = ({backendUrl}) => {
     0,
   );
 
+  console.log("Chats", user.chats);
+
   return (
     <div className='text-left'>
       <form>

--- a/src/components/ChatTableUserB.tsx
+++ b/src/components/ChatTableUserB.tsx
@@ -33,23 +33,25 @@ const ChatTableUserB: React.FC<ChatTableUserBProps> = ({backendUrl}) => {
   return (
     <div className='text-left'>
       <form>
-        {user.chats.map(item => (
-          <Cell
-            key={item.id}
-            Component='label'
-            before={
-              <Multiselectable
-                name='multiselect'
-                value={String(item.id)}
-                checked={selectedValues.includes(String(item.id))}
-                onChange={() => handleSelectionChange(String(item.id))}
-              />
-            }
-            multiline
-          >
-            <strong>{item.words} Points </strong> - {item.name}
-          </Cell>
-        ))}
+        {user.chats
+          .filter(item => item.lead_id !== user.id && item.status === "pending")
+          .map(item => (
+            <Cell
+              key={item.id}
+              Component='label'
+              before={
+                <Multiselectable
+                  name='multiselect'
+                  value={String(item.id)}
+                  checked={selectedValues.includes(String(item.id))}
+                  onChange={() => handleSelectionChange(String(item.id))}
+                />
+              }
+              multiline
+            >
+              <strong>{item.words} Points </strong> - {item.name}
+            </Cell>
+          ))}
       </form>
       <div className='text-center'>
         <Button mode='filled' size='m' onClick={handleAgree}>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -49,6 +49,7 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
   const [pinString, setPinString] = useState("");
 
   const {user, setUser, setIsLoggedIn} = useUserContext() as UserContextProps;
+  console.log("Login component");
   console.log("User:", user);
 
   // This should be placed in a different file maybe Home.tsx and should use useUserContext instead of getUserDataFromBackend

--- a/src/components/UserContext.tsx
+++ b/src/components/UserContext.tsx
@@ -18,7 +18,7 @@ const UserContext = createContext<UserContextProps | undefined>(undefined);
 const UserProvider: React.FC<UserProviderProps> = ({children}) => {
   const [user, setUser] = useState<User>({
     id: 0,
-    name: "",
+    name: "defaultNameUseState",
     chats: [],
   });
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
@@ -47,6 +47,8 @@ const UserProvider: React.FC<UserProviderProps> = ({children}) => {
 
     fetchUserData();
   }, []);
+
+  console.log("User before return in UserContext", user);
 
   return (
     <UserContext.Provider value={{user, setUser, isLoggedIn, setIsLoggedIn}}>

--- a/src/mocks/resolvers/getUserResolver.ts
+++ b/src/mocks/resolvers/getUserResolver.ts
@@ -119,6 +119,8 @@ export const getUserResolver = async ({request}: {request: Request}) => {
       return HttpResponse.json(newUser);
     case 3:
       return HttpResponse.json(inviteeUser);
+    case 4:
+      return HttpResponse.json(normalUser);
     default:
       return new HttpResponse("User not found", {
         status: 404,

--- a/src/mocks/resolvers/getUserResolver.ts
+++ b/src/mocks/resolvers/getUserResolver.ts
@@ -8,12 +8,12 @@ interface GetUserRequestBody {
 }
 
 // The leadUser here is only user as User for inviteeUser and normalUser, the leadUser is created with createLeadUser
-const leadUser: Partial<User> = {
-  id: 1,
-  name: "Lead User",
-  chats: [],
-  has_profile: true,
-};
+// const leadUser: Partial<User> = {
+//   id: 1,
+//   name: "Lead User",
+//   chats: [],
+//   has_profile: true,
+// };
 
 const newUser: Partial<User> = {
   id: 2,
@@ -38,61 +38,75 @@ const normalUser: Partial<User> = {
 
 inviteeUser.chats = [
   {
-    lead_id: newUser.id!,
-    agreed_users: [newUser.id!],
+    lead_id: 2,
+    agreed_users: [2],
     name: "New User",
     id: 2,
     status: "pending",
     words: 50,
-    users: [newUser as User], // Cast to User
+    users: [{id: 2, name: "New User", chats: []}], // Simplified user info
   },
   {
-    lead_id: leadUser.id!,
-    agreed_users: [leadUser.id!],
+    lead_id: 1,
+    agreed_users: [1],
     name: "Lead User",
     id: 1,
     status: "pending",
     words: 230,
-    users: [leadUser as User], // Cast to User
+    users: [{id: 1, name: "Lead User", chats: []}], // Simplified user info
   },
   {
-    lead_id: normalUser.id!,
-    agreed_users: [normalUser.id!],
+    lead_id: 4,
+    agreed_users: [4],
     name: "Normal User",
     id: 4,
     status: "pending",
     words: 10,
-    users: [normalUser as User], // Cast to User
+    users: [{id: 4, name: "Normal User", chats: []}], // Simplified user info
   },
 ];
 
 normalUser.chats = [
   {
-    lead_id: normalUser.id!,
-    agreed_users: [newUser.id!, leadUser.id!],
+    lead_id: 4,
+    agreed_users: [1],
     name: "Normal User Lead Chat",
     id: 5,
     status: "pending",
     words: 100,
-    users: [normalUser as User, newUser as User, leadUser as User], // Cast to User
+    // users: [normalUser as User, newUser as User, leadUser as User], // Cast to User
+    users: [
+      {id: 4, name: "Normal User", chats: []},
+      {id: 2, name: "New User", chats: []},
+      {id: 1, name: "Lead User", chats: []},
+    ],
   },
   {
-    lead_id: leadUser.id!,
-    agreed_users: [normalUser.id!],
+    lead_id: 1,
+    agreed_users: [4],
     name: "Lead User Lead Chat",
     id: 6,
     status: "pending",
     words: 200,
-    users: [leadUser as User, normalUser as User], // Cast to User
+    // users: [leadUser as User, normalUser as User], // Cast to User
+    users: [
+      {id: 1, name: "Lead User", chats: []},
+      {id: 4, name: "Normal User", chats: []},
+    ],
   },
   {
-    lead_id: newUser.id!,
-    agreed_users: [normalUser.id!],
+    lead_id: 2,
+    agreed_users: [1],
     name: "New User Lead Chat",
     id: 7,
     status: "pending",
     words: 150,
-    users: [newUser as User, normalUser as User], // Cast to User
+    // users: [newUser as User, normalUser as User], // Cast to User
+    users: [
+      {id: 2, name: "New User", chats: []},
+      {id: 1, name: "Lead User", chats: []},
+      {id: 4, name: "Normal User", chats: []},
+    ],
   },
 ];
 

--- a/src/mocks/resolvers/getUserResolver.ts
+++ b/src/mocks/resolvers/getUserResolver.ts
@@ -7,9 +7,12 @@ interface GetUserRequestBody {
   username: string;
 }
 
-const getLeadUser = () => {
-  const numChats = parseInt(import.meta.env.VITE_NUM_CHATS || "1", 10);
-  return createLeadUser(numChats);
+// The leadUser here is only user as User for inviteeUser and normalUser, the leadUser is created with createLeadUser
+const leadUser: Partial<User> = {
+  id: 1,
+  name: "Lead User",
+  chats: [],
+  has_profile: true,
 };
 
 const newUser: Partial<User> = {
@@ -22,36 +25,80 @@ const newUser: Partial<User> = {
 const inviteeUser: Partial<User> = {
   id: 3,
   name: "Invitee User",
-  chats: [
-    {
-      lead_id: 2,
-      agreed_users: [1],
-      name: "Invitee Chat",
-      id: 2,
-      status: "sold",
-      words: 50,
-      users: [],
-    },
-    {
-      lead_id: 3,
-      agreed_users: [1],
-      name: "Daniel",
-      id: 3,
-      status: "pending",
-      words: 230,
-      users: [],
-    },
-    {
-      lead_id: 4,
-      agreed_users: [1],
-      name: "Stefano",
-      id: 4,
-      status: "declined",
-      words: 10,
-      users: [],
-    },
-  ],
+  chats: [],
   has_profile: false,
+};
+
+const normalUser: Partial<User> = {
+  id: 4,
+  name: "Normal User",
+  chats: [],
+  has_profile: true,
+};
+
+inviteeUser.chats = [
+  {
+    lead_id: newUser.id!,
+    agreed_users: [newUser.id!],
+    name: "New User",
+    id: 2,
+    status: "pending",
+    words: 50,
+    users: [newUser as User], // Cast to User
+  },
+  {
+    lead_id: leadUser.id!,
+    agreed_users: [leadUser.id!],
+    name: "Lead User",
+    id: 1,
+    status: "pending",
+    words: 230,
+    users: [leadUser as User], // Cast to User
+  },
+  {
+    lead_id: normalUser.id!,
+    agreed_users: [normalUser.id!],
+    name: "Normal User",
+    id: 4,
+    status: "pending",
+    words: 10,
+    users: [normalUser as User], // Cast to User
+  },
+];
+
+normalUser.chats = [
+  {
+    lead_id: normalUser.id!,
+    agreed_users: [newUser.id!, leadUser.id!],
+    name: "Normal User Lead Chat",
+    id: 5,
+    status: "pending",
+    words: 100,
+    users: [normalUser as User, newUser as User, leadUser as User], // Cast to User
+  },
+  {
+    lead_id: leadUser.id!,
+    agreed_users: [normalUser.id!],
+    name: "Lead User Lead Chat",
+    id: 6,
+    status: "pending",
+    words: 200,
+    users: [leadUser as User, normalUser as User], // Cast to User
+  },
+  {
+    lead_id: newUser.id!,
+    agreed_users: [normalUser.id!],
+    name: "New User Lead Chat",
+    id: 7,
+    status: "pending",
+    words: 150,
+    users: [newUser as User, normalUser as User], // Cast to User
+  },
+];
+
+const getLeadUser = () => {
+  const numChats = parseInt(import.meta.env.VITE_NUM_CHATS || "1", 10);
+  return createLeadUser(numChats);
 };
 
 export const getUserResolver = async ({request}: {request: Request}) => {

--- a/src/mocks/resolvers/loginResolver.ts
+++ b/src/mocks/resolvers/loginResolver.ts
@@ -22,10 +22,17 @@ export const loginResolver = async ({request}: {request: Request}) => {
   console.log("phone:", phone);
   console.log("code:", code);
   if (code === "12345") {
-    const mockChats: {[key: string]: number} = {
-      "(1, 'John Doe')": 100,
-      "(2, 'Jane Smith')": 200,
-    }; // Example mock data
+    const numChatsToSell = parseInt(
+      import.meta.env.VITE_NUM_CHATS_TO_SELL || "2",
+      10,
+    );
+    // const mockChats: {[key: string]: number} = {
+    //   "(1, 'John Doe')": 100,
+    //   "(2, 'Jane Smith')": 200,
+    const mockChats: {[key: string]: number} = {};
+    for (let i = 1; i <= numChatsToSell; i++) {
+      mockChats[`(${i}, 'User ${i}')`] = 100 * i;
+    } // Example mock data
     return new HttpResponse(JSON.stringify(mockChats), {
       status: 200,
       headers: {"Content-Type": "application/json"},

--- a/src/mocks/userHandlers.ts
+++ b/src/mocks/userHandlers.ts
@@ -1,79 +1,79 @@
-// mocks/userHandlers.ts
-import {http, HttpResponse} from "msw";
-import {User} from "../types/types";
+// // mocks/userHandlers.ts
+// import {http, HttpResponse} from "msw";
+// import {User} from "../types/types";
 
-const backendUrl = import.meta.env.VITE_BACKEND_URL;
+// const backendUrl = import.meta.env.VITE_BACKEND_URL;
 
-const leadUser: Partial<User> = {
-  id: 1,
-  name: "John Doe",
-  chats: [
-    {
-      lead_id: 1,
-      agreed_users: [2, 3],
-      name: "Chat with Team",
-      id: 1,
-      status: "active",
-      words: 120,
-      users: [],
-    },
-  ],
-  has_profile: true,
-};
+// const leadUser: Partial<User> = {
+//   id: 1,
+//   name: "John Doe",
+//   chats: [
+//     {
+//       lead_id: 1,
+//       agreed_users: [2, 3],
+//       name: "Chat with Team",
+//       id: 1,
+//       status: "active",
+//       words: 120,
+//       users: [],
+//     },
+//   ],
+//   has_profile: true,
+// };
 
-const newUser: Partial<User> = {
-  id: 2,
-  name: "New User",
-  chats: [],
-  has_profile: false,
-};
+// const newUser: Partial<User> = {
+//   id: 2,
+//   name: "New User",
+//   chats: [],
+//   has_profile: false,
+// };
 
-const inviteeUser: Partial<User> = {
-  id: 3,
-  name: "Invitee User",
-  chats: [
-    {
-      lead_id: 2,
-      agreed_users: [1],
-      name: "Invitee Chat",
-      id: 2,
-      status: "pending",
-      words: 50,
-      users: [],
-    },
-  ],
-  has_profile: false,
-};
+// const inviteeUser: Partial<User> = {
+//   id: 3,
+//   name: "Invitee User",
+//   chats: [
+//     {
+//       lead_id: 2,
+//       agreed_users: [1],
+//       name: "Invitee Chat",
+//       id: 2,
+//       status: "pending",
+//       words: 50,
+//       users: [],
+//     },
+//   ],
+//   has_profile: false,
+// };
 
-interface GetUserRequestBody {
-  userId: number;
-  username: string;
-}
+// interface GetUserRequestBody {
+//   userId: number;
+//   username: string;
+// }
 
-export const userHandlers = [
-  http.post(`${backendUrl}/get-user`, async ({request}) => {
-    const json = await request.json();
+// export const userHandlers = [
+//   http.post(`${backendUrl}/get-user`, async ({request}) => {
+//     const json = await request.json();
 
-    if (!json || typeof json !== "object") {
-      return new HttpResponse("Invalid request body", {
-        status: 400,
-        headers: {"Content-Type": "application/json"},
-      });
-    }
-    const body = json as GetUserRequestBody;
-    const {userId} = body;
-    switch (userId) {
-      case 1:
-        return HttpResponse.json(leadUser);
-      case 2:
-        return HttpResponse.json(newUser);
-      case 3:
-        return HttpResponse.json(inviteeUser);
-      default:
-        return new HttpResponse("User not found", {
-          status: 404,
-          headers: {"Content-Type": "application/json"},
-        });
-    }
-  }),
-];
+//     if (!json || typeof json !== "object") {
+//       return new HttpResponse("Invalid request body", {
+//         status: 400,
+//         headers: {"Content-Type": "application/json"},
+//       });
+//     }
+//     const body = json as GetUserRequestBody;
+//     const {userId} = body;
+//     switch (userId) {
+//       case 1:
+//         return HttpResponse.json(leadUser);
+//       case 2:
+//         return HttpResponse.json(newUser);
+//       case 3:
+//         return HttpResponse.json(inviteeUser);
+//       default:
+//         return new HttpResponse("User not found", {
+//           status: 404,
+//           headers: {"Content-Type": "application/json"},
+//         });
+//     }
+//   }),
+// ];

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -10,11 +10,11 @@ export interface Chat {
 }
 
 // Define the ChatStatus type
-// export type ChatStatus = {
-//   sold: string[];
-//   pending: string[];
-//   declined: string[];
-// };
+export type ChatStatus = {
+  sold: string[];
+  pending: string[];
+  declined: string[];
+};
 
 // Define the ChatDetails type
 export type ChatDetails = {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -40,6 +40,7 @@ export interface User {
   telephoneNumber?: string;
   auth_status?: string;
   chats: Chat[];
+  chatsToSell?: {[key: string]: number}; // New property to hold the data returned by /login
 }
 
 // Define the TelegramUser interface with required Telegram-specific properties

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -41,6 +41,11 @@ export interface User {
   auth_status?: string;
   chats: Chat[];
   chatsToSell?: {[key: string]: number}; // New property to hold the data returned by /login
+  chatsToSellUnfolded?: Array<{
+    userId: number;
+    userName: string;
+    words: number;
+  }>; // Unfolded data
 }
 
 // Define the TelegramUser interface with required Telegram-specific properties

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -10,11 +10,11 @@ export interface Chat {
 }
 
 // Define the ChatStatus type
-export type ChatStatus = {
-  sold: string[];
-  pending: string[];
-  declined: string[];
-};
+// export type ChatStatus = {
+//   sold: string[];
+//   pending: string[];
+//   declined: string[];
+// };
 
 // Define the ChatDetails type
 export type ChatDetails = {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,4 +1,5 @@
 // Define the Chat interface for your application
+// The status we get from the backend can be 'sold', 'pending', or 'error'. Chats were the user is an invitee will be 'pending' but the lead_id will be different from the user's id.
 export interface Chat {
   lead_id: number;
   agreed_users: number[];

--- a/src/utils/api/loginHandler.ts
+++ b/src/utils/api/loginHandler.ts
@@ -1,4 +1,4 @@
-import {Chat} from "../../types/types";
+// import {Chat} from "../../types/types";
 
 interface LoginHandlerProps {
   phone: string;
@@ -6,48 +6,50 @@ interface LoginHandlerProps {
   backendUrl: string;
 }
 
-interface HandleLoginResponseProps {
-  responseData: {[key: string]: number};
-}
+// interface HandleLoginResponseProps {
+//   responseData: {[key: string]: number};
+// }
 
-const transformData = (data: {[key: string]: number}): Chat[] => {
-  const chats: Chat[] = [];
+// const transformData = (data: {[key: string]: number}): Chat[] => {
+//   const chats: Chat[] = [];
 
-  for (const key in data) {
-    if (Object.prototype.hasOwnProperty.call(data, key)) {
-      const keyParts = key.match(/\((\d+), '(.+?)'\)/);
-      if (keyParts && keyParts.length === 3) {
-        const userId = parseInt(keyParts[1], 10); // Parse id as number
-        const userName = keyParts[2];
-        const words = data[key];
+//   for (const key in data) {
+//     if (Object.prototype.hasOwnProperty.call(data, key)) {
+//       const keyParts = key.match(/\((\d+), '(.+?)'\)/);
+//       if (keyParts && keyParts.length === 3) {
+//         const userId = parseInt(keyParts[1], 10); // Parse id as number
+//         const userName = keyParts[2];
+//         const words = data[key];
 
-        chats.push({
-          id: userId,
-          name: userName,
-          words,
-          lead_id: 0, // Default or modify as needed
-          agreed_users: [], // Default or modify as needed
-          status: "", // Default or modify as needed
-          users: [], // Default or modify as needed
-        });
-      }
-    }
-  }
+//         chats.push({
+//           id: userId,
+//           name: userName,
+//           words,
+//           lead_id: 0, // Default or modify as needed
+//           agreed_users: [], // Default or modify as needed
+//           status: "", // Default or modify as needed
+//           users: [], // Default or modify as needed
+//         });
+//       }
+//     }
+//   }
 
-  return chats;
-};
+//   return chats;
+// };
 
-export const handleLoginResponse = ({
-  responseData,
-}: HandleLoginResponseProps) => {
-  return transformData(responseData);
-};
+// export const handleLoginResponse = ({
+//   responseData,
+// }: HandleLoginResponseProps) => {
+//   //   return transformData(responseData);
+//   return transformChatsToSell(responseData);
+// };
 
 export const loginHandler = async ({
   phone,
   pinString,
   backendUrl,
-}: LoginHandlerProps): Promise<Chat[]> => {
+  // }: LoginHandlerProps): Promise<Chat[]> => {
+}: LoginHandlerProps): Promise<{[key: string]: number}> => {
   try {
     console.log("Verifying code:", pinString);
     const response = await fetch(`${backendUrl}/login`, {
@@ -69,9 +71,10 @@ export const loginHandler = async ({
 
     const responseData: {[key: string]: number} = await response.json();
     console.log(responseData);
-    return handleLoginResponse({
-      responseData,
-    });
+    // return handleLoginResponse({
+    //   responseData,
+    // });
+    return responseData;
   } catch (error) {
     console.error("Error verifying code:", error);
     throw new Error("Error verifying code: " + error);


### PR DESCRIPTION
- [x] create appropriate mock users: User A (lead), User B (invitee), User N (new), User R (regular) chats. The User A will have only chats, in which they are the lead_id, User B, where they are not lead_id, User R a mix of both, User N no chats at all. The users are created in the getUserResolver.ts (new, invitee, normal) and in createUsers.ts (lead).
- [ ] Switch id number for mocked users. Atm lead is 1, new is 2, invitee is 3 an normal is 4. Switch lead and new. This needs to be changed not only in getUserResolver but also in the mocked function that gives back the Telegram User id. 
- [x] getUserDataFromTelegram: check the flow again and how `setMockedTelegramUser` prepare the type of User based on the value in `.env`
- [x] getUserDataFromBackend: check the flow again and make sure that we have proper chat-sets for each user in the `getUserResolver` callback for the /get-user endpoint. Each user means: lead, invitee, new and regular. 
- [x] Check what effect have the different Users in **App.tsx** and if any: I removed some condition in useEffect, to switch tab, which were not working (legacy logic) or had no practical effect, the last else if branch.  
- [x] Do the same check in **Home.tsx**.
- [x] Fix logic in ChatTable.tsx and ChatTableUserB.tsx: they should show different kind of chats. The ChatTable component will show the "My Chat" chats, i.e. the chat that the user can sell, and which they get back from /login. ChatTable will show the "My Invitation" chats, i.e. the chats that are already retrieved from `getUserDataFromBackend` /get-user, which are the chats which are `pending` and in which the user.id is different by the lead_id and to which the user didn't agree yet. 
- [x] add `chatsToSell` to the User object: `chatsToSell?: { [key: string]: number };` which holds the data returned by /login. We get the chats the user wants to sell only when the user hit /login and the chats 'to sell' are not saved in the profile of the user if he/she doesn't agree to sell them. If he/she does they become 'pending' (the chosen ones), the other ones get forgotten.
- [x] Care that the /login mock returns an adequate numbers of chatToSell, maybe specified in the .env. User A, who is a User N, till to /login will get. All users (A, B, N, R) could get some chatsToSell hitting /login. We have a new variable VITE_NUM_CHATS_TO_SELL, with default 2, used in the loginResolver, to mock this. The two relevant functions here are loginHandler in loginHandler.ts and loginResolver in loginResolver.tx. Change the type return by /login. It was strangely Chat and it should had been. It was this   `Promise<Chat[]>` but it should have been `Promise<{[key: string]: number}>` (also before). Can you check this? @lmangall & @Danielg1406. Old code is commented out (in loginHandler.ts)
- [x] check the Login component where the loginHandler function is called. 
- [x] remove handleLoginResponse, a wrapper, which does nothing, rename transformData in transformChatToSell and add   `chatsToSellUnfolded?: Array<{ userId: number; userName: string; words: number }>;` to store the data of the chats in a similar way they were stored in chats. 
- [x] In ChatTableUserB filters out from all the chats the invitations: 'pending' status, and lead_id is different from the user.id. 
- [x] In ChatTable display the chatToSellUnfolded we got back from the /login endpoint.
- [x] Test with a User R.
- [x] Debug `chunk-DUSGMV2A.js?v=e92b0513:97 [MSW] Uncaught exception in the request handler for "POST https://quart-backend-4fd6o.ondigitalocean.app/get-user":`. The chats of the Normal User are not correctly saved in the User object.

 