### PR TITLE
Implement user leave app to check pin

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Home from "./components/Home";
 import Chats from "./components/Chats";
 import Social from "./components/Social";
 import Quest from "./components/Quest";
+import Login from "./components/Login";
 import {Tabbar} from "@telegram-apps/telegram-ui";
 import {UserProvider} from "./components/UserContext";
 import {useUserContext} from "./utils/utils";
@@ -39,6 +40,11 @@ const AppContent: React.FC = () => {
 
   const backendUrl: string = getBackendUrl();
 
+  const handleLoginSuccess = () => {
+    // Define what should happen on successful login
+    setCurrentTab(tabs[0].id); // For example, redirect to home tab
+  };
+
   useEffect(() => {
     if (!hasTrackedAppEntered.current) {
       console.log("Tracking App Entered event");
@@ -61,6 +67,15 @@ const AppContent: React.FC = () => {
     }
   }, [eventBuilder, user.chats.length, user.has_profile, user.id]);
 
+  useEffect(() => {
+    if (user.auth_status === "auth_code") {
+      console.log(user.auth_status);
+      console.log(
+        "auth_status is auth_code, (means user went through /send-code) redirecting to login tab",
+      );
+    }
+  }, [user.auth_status]);
+
   const handleTabClick = (id: string) => {
     setCurrentTab(id);
     eventBuilder.track("Tab Clicked", {
@@ -72,6 +87,12 @@ const AppContent: React.FC = () => {
       `Tab Clicked event tracked: { userId: ${user.id}, tabId: ${id} }`,
     );
   };
+
+  if (user.auth_status === "auth_code") {
+    return (
+      <Login onLoginSuccess={handleLoginSuccess} backendUrl={backendUrl} />
+    );
+  }
 
   return (
     <div>
@@ -114,4 +135,5 @@ export function App() {
     </TwaAnalyticsProvider>
   );
 }
+
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,6 @@ import Home from "./components/Home";
 import Chats from "./components/Chats";
 import Social from "./components/Social";
 import Quest from "./components/Quest";
-import Login from "./components/Login";
 import {Tabbar} from "@telegram-apps/telegram-ui";
 import {UserProvider} from "./components/UserContext";
 import {useUserContext} from "./utils/utils";
@@ -40,11 +39,6 @@ const AppContent: React.FC = () => {
 
   const backendUrl: string = getBackendUrl();
 
-  const handleLoginSuccess = () => {
-    // Define what should happen on successful login
-    setCurrentTab(tabs[0].id); // For example, redirect to home tab
-  };
-
   useEffect(() => {
     if (!hasTrackedAppEntered.current) {
       console.log("Tracking App Entered event");
@@ -73,6 +67,7 @@ const AppContent: React.FC = () => {
       console.log(
         "auth_status is auth_code, (means user went through /send-code) redirecting to login tab",
       );
+      setCurrentTab(tabs[1].id);
     }
   }, [user.auth_status]);
 
@@ -87,12 +82,6 @@ const AppContent: React.FC = () => {
       `Tab Clicked event tracked: { userId: ${user.id}, tabId: ${id} }`,
     );
   };
-
-  if (user.auth_status === "auth_code") {
-    return (
-      <Login onLoginSuccess={handleLoginSuccess} backendUrl={backendUrl} />
-    );
-  }
 
   return (
     <div>

--- a/src/components/Chats.tsx
+++ b/src/components/Chats.tsx
@@ -14,22 +14,35 @@ const Chats: React.FC<{backendUrl: string}> = ({backendUrl}) => {
   // Update state based on user profile and chats
   useEffect(() => {
     if (user) {
-      if (!user.has_profile && user.chats.length > 0) {
-        setShowChatTableUserB(true);
-        setShowChatTable(false);
-        console.log(
-          "User doesn't have a profile but has at least one chat, showing ChatTableUserB",
-        );
+      if (!user.has_profile) {
+        if (user.chats.length > 0) {
+          console.log(
+            "User doesn't have a profile but has at least one chat, showing ChatTableUserB",
+          );
+          setShowChatTableUserB(true);
+          setShowChatTable(false);
+        } else {
+          console.log(
+            "User doesn't have a profile and has no chats, showing Login",
+          );
+          setShowChatTable(false);
+          setShowChatTableUserB(false);
+          setShowLogin(true);
+          console.log(
+            "User doesn't have a profile and has no chats, showing Login",
+          );
+        }
       } else if (user.has_profile) {
-        setShowChatTable(true);
-        if (!isLoggedIn) {
+        if (isLoggedIn) {
+          console.log("User has a profile, showing ChatTable");
+          setShowChatTable(true);
+          setShowChatTableUserB(false);
+        } else {
+          setShowChatTable(false);
+          setShowChatTableUserB(false);
           setShowLogin(true);
         }
         setShowChatTableUserB(false);
-        console.log("User has a profile, showing ChatTable");
-      } else {
-        setShowChatTable(false);
-        console.log("User doesn't have a profile, showing ChatTableUserB");
       }
     }
   }, [user, isLoggedIn]);

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -101,7 +101,7 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
       try {
         console.log("Verifying code:", pinString);
         const chatsToSell = await loginHandler({
-          phone,
+          phone: user.auth_status === "auth_code" ? "" : phone,
           pinString,
           backendUrl,
           userId: user.id,
@@ -137,6 +137,7 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
     setIsLoggedIn,
     onLoginSuccess,
     user.id,
+    user.auth_status,
   ]);
 
   return (
@@ -148,7 +149,7 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
         textAlign: "center",
       }}
     >
-      {!isPhoneSubmitted ? (
+      {!isPhoneSubmitted && user.auth_status !== "auth_code" ? (
         <>
           <Placeholder
             description='Log in to check the value of your chats'
@@ -191,7 +192,7 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
         </>
       ) : (
         <>
-          <Placeholder />
+          {user.auth_status !== "auth_code" && <Placeholder />}
           <PinInput
             pinCount={5}
             onChange={handlePinChange}

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useEffect} from "react";
 import {
   Button,
-  Input,
+  Textarea,
   Checkbox,
   Placeholder,
   PinInput,
@@ -155,12 +155,14 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
             description='Log in to check the value of your chats'
             header='Login'
           />
-          <Input
+          {/* changed from Input to Textarea with hope that it will have a border */}
+          <Textarea
             status='focused'
             header='Phone Number'
             placeholder='Enter your phone number'
             value={phone}
             onChange={handleInputChange}
+            style={{height: "40px"}}
           />
           <Placeholder>
             <div style={{display: "flex", alignItems: "center"}}>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -104,6 +104,7 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
           phone,
           pinString,
           backendUrl,
+          userId: user.id,
         });
 
         const chatsToSellUnfolded = transformChatsToSell(chatsToSell);
@@ -128,7 +129,15 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
     if (pinString.length === 5) {
       verifyCode();
     }
-  }, [pinString, phone, backendUrl, setUser, setIsLoggedIn, onLoginSuccess]);
+  }, [
+    pinString,
+    phone,
+    backendUrl,
+    setUser,
+    setIsLoggedIn,
+    onLoginSuccess,
+    user.id,
+  ]);
 
   return (
     <div

--- a/src/components/Modals/AgreeSale.tsx
+++ b/src/components/Modals/AgreeSale.tsx
@@ -105,7 +105,7 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
             </div>
           </div>
           <Textarea
-            header='Textarea'
+            header='The invitation for your friend'
             placeholder='I am usual textarea'
             value={message}
             onChange={handleMessageChange}

--- a/src/mocks/resolvers/getUserResolver.ts
+++ b/src/mocks/resolvers/getUserResolver.ts
@@ -36,6 +36,22 @@ const normalUser: Partial<User> = {
   has_profile: true,
 };
 
+const newAuthCodeUser: Partial<User> = {
+  id: 5,
+  name: "AuthCode User",
+  chats: [],
+  has_profile: false,
+  auth_status: "auth_code",
+};
+
+const newChooseChatUser: Partial<User> = {
+  id: 6,
+  name: "ChooseChat User",
+  chats: [],
+  has_profile: true,
+  auth_status: "choose_chat",
+};
+
 inviteeUser.chats = [
   {
     lead: {
@@ -86,7 +102,6 @@ normalUser.chats = [
     id: "5",
     status: "pending",
     words: 100,
-    // users: [normalUser as User, newUser as User, leadUser as User], // Cast to User
     users: [
       {id: 4, name: "Normal User", chats: []},
       {id: 2, name: "New User", chats: []},
@@ -103,7 +118,6 @@ normalUser.chats = [
     id: "6",
     status: "pending",
     words: 200,
-    // users: [leadUser as User, normalUser as User], // Cast to User
     users: [
       {id: 1, name: "Lead User", chats: []},
       {id: 4, name: "Normal User", chats: []},
@@ -119,7 +133,6 @@ normalUser.chats = [
     id: "7",
     status: "pending",
     words: 150,
-    // users: [newUser as User, normalUser as User], // Cast to User
     users: [
       {id: 2, name: "New User", chats: []},
       {id: 1, name: "Lead User", chats: []},
@@ -153,6 +166,10 @@ export const getUserResolver = async ({request}: {request: Request}) => {
       return HttpResponse.json(inviteeUser);
     case 4:
       return HttpResponse.json(normalUser);
+    case 5:
+      return HttpResponse.json(newAuthCodeUser);
+    case 6:
+      return HttpResponse.json(newChooseChatUser);
     default:
       return new HttpResponse("User not found", {
         status: 404,

--- a/src/mocks/resolvers/loginResolver.ts
+++ b/src/mocks/resolvers/loginResolver.ts
@@ -3,6 +3,7 @@ import {HttpResponse} from "msw";
 interface LoginRequestBody {
   phone: string;
   code: string;
+  user_id: string;
 }
 
 export const loginResolver = async ({request}: {request: Request}) => {
@@ -16,11 +17,12 @@ export const loginResolver = async ({request}: {request: Request}) => {
   }
 
   const body = json as LoginRequestBody;
-  // TODO: Let the mock function collect the code from the component
-  //   body.phone = "12345";
-  const {phone, code} = body;
+  const {phone, code, user_id} = body;
+
   console.log("phone:", phone);
   console.log("code:", code);
+  console.log("user_id:", user_id);
+
   if (code === "12345") {
     const numChatsToSell = parseInt(
       import.meta.env.VITE_NUM_CHATS_TO_SELL || "2",
@@ -29,9 +31,8 @@ export const loginResolver = async ({request}: {request: Request}) => {
     const mockChats: {[key: string]: number} = {};
     for (let i = 1; i <= numChatsToSell; i++) {
       mockChats[`(${i}, 'User ${i}')`] = 100 * i;
-    } // Example mock data
+    }
 
-    // Add a 3-second delay before returning the mock chats
     await new Promise(resolve => setTimeout(resolve, 3000));
 
     return new HttpResponse(JSON.stringify(mockChats), {

--- a/src/utils/api/loginHandler.ts
+++ b/src/utils/api/loginHandler.ts
@@ -21,7 +21,7 @@ export const loginHandler = async ({
       body: JSON.stringify({
         phone_number: phone,
         code: pinString,
-        user_id: userId,
+        userId: userId,
       }),
     });
 

--- a/src/utils/api/loginHandler.ts
+++ b/src/utils/api/loginHandler.ts
@@ -1,54 +1,15 @@
-// import {Chat} from "../../types/types";
-
 interface LoginHandlerProps {
   phone: string;
   pinString: string;
   backendUrl: string;
+  userId: string;
 }
-
-// interface HandleLoginResponseProps {
-//   responseData: {[key: string]: number};
-// }
-
-// const transformData = (data: {[key: string]: number}): Chat[] => {
-//   const chats: Chat[] = [];
-
-//   for (const key in data) {
-//     if (Object.prototype.hasOwnProperty.call(data, key)) {
-//       const keyParts = key.match(/\((\d+), '(.+?)'\)/);
-//       if (keyParts && keyParts.length === 3) {
-//         const userId = parseInt(keyParts[1], 10); // Parse id as number
-//         const userName = keyParts[2];
-//         const words = data[key];
-
-//         chats.push({
-//           id: userId,
-//           name: userName,
-//           words,
-//           lead_id: 0, // Default or modify as needed
-//           agreed_users: [], // Default or modify as needed
-//           status: "", // Default or modify as needed
-//           users: [], // Default or modify as needed
-//         });
-//       }
-//     }
-//   }
-
-//   return chats;
-// };
-
-// export const handleLoginResponse = ({
-//   responseData,
-// }: HandleLoginResponseProps) => {
-//   //   return transformData(responseData);
-//   return transformChatsToSell(responseData);
-// };
 
 export const loginHandler = async ({
   phone,
   pinString,
   backendUrl,
-  // }: LoginHandlerProps): Promise<Chat[]> => {
+  userId,
 }: LoginHandlerProps): Promise<{[key: string]: number}> => {
   try {
     console.log("Verifying code:", pinString);
@@ -60,6 +21,7 @@ export const loginHandler = async ({
       body: JSON.stringify({
         phone_number: phone,
         code: pinString,
+        user_id: userId,
       }),
     });
 
@@ -71,9 +33,6 @@ export const loginHandler = async ({
 
     const responseData: {[key: string]: number} = await response.json();
     console.log(responseData);
-    // return handleLoginResponse({
-    //   responseData,
-    // });
     return responseData;
   } catch (error) {
     console.error("Error verifying code:", error);

--- a/src/utils/api/loginHandler.ts
+++ b/src/utils/api/loginHandler.ts
@@ -2,7 +2,7 @@ interface LoginHandlerProps {
   phone: string;
   pinString: string;
   backendUrl: string;
-  userId: string;
+  userId: number;
 }
 
 export const loginHandler = async ({

--- a/src/utils/mocks.ts
+++ b/src/utils/mocks.ts
@@ -36,6 +36,26 @@ export const setMockedTelegramUser = () => {
           has_profile: true,
         };
         break;
+      case "new_auth_code":
+        user = {
+          id: 5,
+          first_name: "AuthCode",
+          last_name: "User",
+          chats: [],
+          has_profile: false,
+          auth_status: "auth_code",
+        };
+        break;
+      case "new_choose_chat":
+        user = {
+          id: 6,
+          first_name: "ChooseChat",
+          last_name: "User",
+          chats: [],
+          has_profile: true,
+          auth_status: "choose_chat",
+        };
+        break;
       default:
         user = {id: 0, first_name: "Default", last_name: "User", chats: []};
         break;


### PR DESCRIPTION
**Goal:** User can leave app after sending phone, before verifying pin, and come back to this stage

auth_status has 3 statuses: default, auth_code, choose_chat
 - default means default
 - auth_code means user went through /send-code
 - choose_chat means user went through /login, but not through /send-message


1. implement mocks for users with auth_status
Update .env with: `VITE_USER_TYPE=new_auth_code  # Can be 'lead', 'invitee', 'new', 'new_auth_code', 'new_choose_chat'
'`
2. refactor login.tsx and longinHandler.tsx so they send a `userId`
3. update loginResolver (so our mock fits the backend)
4. refactor login.tsx so it skip phone input for auth_code 
5. modify App.tsx so it conditionaly renders "Chats" tab if user.auth_status is auth_code
6. Fix flawed logic fo "Chats" tab to render ChatTable or ChatTableUserB

Unrelated:
7. use textArea instead of input desperate to show border on mobile 
(as you have noticed in clear mode on mobile the Input component doesn't show border, even with "focus" on (but the border is visible in localhost Dev tools mobile
