### PR TITLE
Leo/cha 509 handle backend error responses

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,11 @@ const AppContent: React.FC = () => {
       setCurrentTab(tabs[1].id);
       sessionStorage.setItem("hasRedirectedToChats", "true");
     }
+
+    if (!user.has_profile) {
+      console.log("User has no profile, switching to chats tab");
+      setCurrentTab(tabs[1].id);
+    }
   }, [
     eventBuilder,
     user.chats.length,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,13 @@
-import React, {useState, useEffect, useRef} from "react";
-import {TwaAnalyticsProvider} from "@tonsolutions/telemetree-react";
+import React, {useEffect, useRef} from "react";
 import {useTWAEvent} from "@tonsolutions/telemetree-react";
+import {TwaAnalyticsProvider} from "@tonsolutions/telemetree-react";
 import Home from "./components/Home";
 import Chats from "./components/Chats";
 import Social from "./components/Social";
 import Quest from "./components/Quest";
 import {Tabbar} from "@telegram-apps/telegram-ui";
-import {UserProvider} from "./components/UserContext";
 import {useUserContext} from "./utils/utils";
+import {UserProvider} from "./components/UserContext";
 
 interface Tab {
   id: string;
@@ -22,8 +22,7 @@ const tabs: Tab[] = [
 ];
 
 const AppContent: React.FC = () => {
-  const [currentTab, setCurrentTab] = useState<string>(tabs[0].id);
-  const {user} = useUserContext();
+  const {user, currentTab, setCurrentTab} = useUserContext();
   const eventBuilder = useTWAEvent();
   const hasTrackedAppEntered = useRef(false);
 
@@ -59,7 +58,13 @@ const AppContent: React.FC = () => {
       setCurrentTab(tabs[1].id);
       sessionStorage.setItem("hasRedirectedToChats", "true");
     }
-  }, [eventBuilder, user.chats.length, user.has_profile, user.id]);
+  }, [
+    eventBuilder,
+    user.chats.length,
+    user.has_profile,
+    user.id,
+    setCurrentTab,
+  ]);
 
   useEffect(() => {
     if (user.auth_status === "auth_code") {
@@ -69,7 +74,7 @@ const AppContent: React.FC = () => {
       );
       setCurrentTab(tabs[1].id);
     }
-  }, [user.auth_status]);
+  }, [user.auth_status, setCurrentTab]);
 
   const handleTabClick = (id: string) => {
     setCurrentTab(id);

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -53,8 +53,10 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
   const [isLoading, setIsLoading] = useState(false);
   const [isPinLoading, setIsPinLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<number | null>(null); // New state for error code
 
-  const {user, setUser, setIsLoggedIn} = useUserContext() as UserContextProps;
+  const {user, setUser, setIsLoggedIn, setCurrentTab} =
+    useUserContext() as UserContextProps;
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setPhone(event.target.value);
@@ -83,6 +85,7 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
       if (!response.ok) {
         const errorMessage = await response.text();
         console.error("Error message:", errorMessage);
+        setErrorCode(response.status); // Set the error code
         throw new Error(errorMessage);
       }
 
@@ -152,6 +155,11 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
     user.auth_status,
   ]);
 
+  const handleRedirect = () => {
+    // Implement your redirect logic here
+    console.log("Redirecting...");
+  };
+
   return (
     <div
       style={{
@@ -164,7 +172,10 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
       {errorMessage && (
         <BackendError
           message={errorMessage}
+          errorCode={errorCode || 0}
           onClose={() => setErrorMessage(null)}
+          onRedirect={handleRedirect}
+          setCurrentTab={setCurrentTab} // Pass setCurrentTab
         />
       )}
       {!isPhoneSubmitted && user.auth_status !== "auth_code" ? (

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -13,6 +13,10 @@ import {loginHandler} from "../utils/api/loginHandler";
 import {UserContextProps} from "../components/UserContext";
 import BackendError from "../utils/BackendError";
 
+interface CustomError extends Error {
+  status?: number;
+}
+
 interface LoginProps {
   onLoginSuccess: () => void;
   backendUrl: string;
@@ -126,16 +130,12 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
         setResponseMessage("Success");
         onLoginSuccess();
       } catch (error) {
-        if (error instanceof Error) {
-          setResponseMessage("Error verifying code: " + error.message);
-          setError({
-            message: "Error verifying code: " + error.message,
-            errorCode: 401,
-          });
-        } else {
-          setResponseMessage("Error verifying code");
-          setError({message: "Error verifying code", errorCode: 401});
-        }
+        const customError = error as CustomError;
+        setResponseMessage("Error verifying code: " + customError.message);
+        setError({
+          message: "Error verifying code: " + customError.message,
+          errorCode: customError.status || 666,
+        });
       } finally {
         setIsPinLoading(false);
       }

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -11,6 +11,7 @@ import {
 import {useUserContext} from "../utils/utils";
 import {loginHandler} from "../utils/api/loginHandler";
 import {UserContextProps} from "../components/UserContext";
+import BackendError from "../utils/BackendError";
 
 interface LoginProps {
   onLoginSuccess: () => void;
@@ -51,6 +52,10 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
   const [pinString, setPinString] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isPinLoading, setIsPinLoading] = useState(false);
+  const [error, setError] = useState<{
+    message: string;
+    errorCode: number;
+  } | null>(null);
 
   const {user, setUser, setIsLoggedIn} = useUserContext() as UserContextProps;
 
@@ -90,6 +95,7 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
     } catch (error) {
       console.error("Error sending phone number:", error);
       setResponseMessage("Error sending phone number");
+      setError({message: "Error sending phone number", errorCode: 400});
     } finally {
       setIsLoading(false);
     }
@@ -121,6 +127,7 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
         onLoginSuccess();
       } catch (error) {
         setResponseMessage("Error verifying code: " + error);
+        setError({message: "Error verifying code: " + error, errorCode: 400});
       } finally {
         setIsPinLoading(false);
       }
@@ -149,13 +156,20 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
         textAlign: "center",
       }}
     >
+      {error && (
+        <BackendError
+          message={error.message}
+          errorCode={error.errorCode}
+          onClose={() => setError(null)}
+          onRedirect={() => setIsPhoneSubmitted(false)}
+        />
+      )}
       {!isPhoneSubmitted && user.auth_status !== "auth_code" ? (
         <>
           <Placeholder
             description='Log in to check the value of your chats'
             header='Login'
           />
-          {/* changed from Input to Textarea with hope that it will have a border */}
           <Textarea
             status='focused'
             header='Phone Number'
@@ -174,7 +188,7 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
               <span style={{whiteSpace: "nowrap"}}>
                 I agree to the{" "}
                 <a
-                  href='https://static1.squarespace.com/static/665b166b65c61d1f819dec7e/t/665c43d3be949513ba28488c/1717322707955/USER+AGREEMENT.pdf'
+                  href='https://www.chatpay.app/user-agreement.pdf'
                   target='_blank'
                   rel='noopener noreferrer'
                 >

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useEffect} from "react";
 import {
   Button,
-  Input,
+  Textarea,
   Checkbox,
   Placeholder,
   PinInput,
@@ -11,7 +11,6 @@ import {
 import {useUserContext} from "../utils/utils";
 import {loginHandler} from "../utils/api/loginHandler";
 import {UserContextProps} from "../components/UserContext";
-import BackendError from "../utils/BackendError";
 
 interface LoginProps {
   onLoginSuccess: () => void;
@@ -52,11 +51,8 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
   const [pinString, setPinString] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isPinLoading, setIsPinLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [errorCode, setErrorCode] = useState<number | null>(null); // New state for error code
 
-  const {user, setUser, setIsLoggedIn, setCurrentTab} =
-    useUserContext() as UserContextProps;
+  const {user, setUser, setIsLoggedIn} = useUserContext() as UserContextProps;
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setPhone(event.target.value);
@@ -78,29 +74,22 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
         },
         body: JSON.stringify({
           phone_number: phone,
-          userId: user.id,
+          user_id: user.id,
         }),
       });
 
       if (!response.ok) {
         const errorMessage = await response.text();
         console.error("Error message:", errorMessage);
-        setErrorCode(response.status); // Set the error code
         throw new Error(errorMessage);
       }
 
       setIsPhoneSubmitted(true);
       setResponseMessage("Verification code sent. Please check your phone.");
       console.log("Verification code sent successfully");
-    } catch (err: unknown) {
-      console.error("Error sending phone number:", err);
-      if (err instanceof Error) {
-        setErrorMessage("Error sending phone number: " + err.message);
-      } else {
-        setErrorMessage(
-          "Error sending phone number: An unknown error occurred.",
-        );
-      }
+    } catch (error) {
+      console.error("Error sending phone number:", error);
+      setResponseMessage("Error sending phone number");
     } finally {
       setIsLoading(false);
     }
@@ -130,12 +119,8 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
         setIsLoggedIn(true);
         setResponseMessage("Success");
         onLoginSuccess();
-      } catch (err: unknown) {
-        if (err instanceof Error) {
-          setErrorMessage("Error verifying code: " + err.message);
-        } else {
-          setErrorMessage("Error verifying code: An unknown error occurred.");
-        }
+      } catch (error) {
+        setResponseMessage("Error verifying code: " + error);
       } finally {
         setIsPinLoading(false);
       }
@@ -155,11 +140,6 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
     user.auth_status,
   ]);
 
-  const handleRedirect = () => {
-    // Implement your redirect logic here
-    console.log("Redirecting...");
-  };
-
   return (
     <div
       style={{
@@ -169,28 +149,20 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
         textAlign: "center",
       }}
     >
-      {errorMessage && (
-        <BackendError
-          message={errorMessage}
-          errorCode={errorCode || 0}
-          onClose={() => setErrorMessage(null)}
-          onRedirect={handleRedirect}
-          setCurrentTab={setCurrentTab} // Pass setCurrentTab
-        />
-      )}
       {!isPhoneSubmitted && user.auth_status !== "auth_code" ? (
         <>
           <Placeholder
             description='Log in to check the value of your chats'
             header='Login'
           />
-          <Input
+          {/* changed from Input to Textarea with hope that it will have a border */}
+          <Textarea
             status='focused'
             header='Phone Number'
             placeholder='Enter your phone number'
             value={phone}
             onChange={handleInputChange}
-            type='tel'
+            style={{height: "40px"}}
           />
           <Placeholder>
             <div style={{display: "flex", alignItems: "center"}}>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -126,8 +126,16 @@ const Login: React.FC<LoginProps> = ({onLoginSuccess, backendUrl}) => {
         setResponseMessage("Success");
         onLoginSuccess();
       } catch (error) {
-        setResponseMessage("Error verifying code: " + error);
-        setError({message: "Error verifying code: " + error, errorCode: 400});
+        if (error instanceof Error) {
+          setResponseMessage("Error verifying code: " + error.message);
+          setError({
+            message: "Error verifying code: " + error.message,
+            errorCode: 401,
+          });
+        } else {
+          setResponseMessage("Error verifying code");
+          setError({message: "Error verifying code", errorCode: 401});
+        }
       } finally {
         setIsPinLoading(false);
       }

--- a/src/components/UserContext.tsx
+++ b/src/components/UserContext.tsx
@@ -7,6 +7,8 @@ export interface UserContextProps {
   setUser: React.Dispatch<React.SetStateAction<User>>;
   isLoggedIn: boolean;
   setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
+  currentTab: string;
+  setCurrentTab: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export interface UserProviderProps {
@@ -22,6 +24,7 @@ const UserProvider: React.FC<UserProviderProps> = ({children}) => {
     chats: [],
   });
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+  const [currentTab, setCurrentTab] = useState<string>("home");
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -51,7 +54,16 @@ const UserProvider: React.FC<UserProviderProps> = ({children}) => {
   console.log("User before return in UserContext", user);
 
   return (
-    <UserContext.Provider value={{user, setUser, isLoggedIn, setIsLoggedIn}}>
+    <UserContext.Provider
+      value={{
+        user,
+        setUser,
+        isLoggedIn,
+        setIsLoggedIn,
+        currentTab,
+        setCurrentTab,
+      }}
+    >
       {children}
     </UserContext.Provider>
   );

--- a/src/mocks/resolvers/loginResolver.ts
+++ b/src/mocks/resolvers/loginResolver.ts
@@ -40,9 +40,14 @@ export const loginResolver = async ({request}: {request: Request}) => {
       headers: {"Content-Type": "application/json"},
     });
   } else {
-    return new HttpResponse("Invalid code", {
-      status: 401,
+    //WARNING: temporarily added to test BackendError
+    return new HttpResponse("user is already logged in", {
+      status: 409,
       headers: {"Content-Type": "application/json"},
     });
+    // return new HttpResponse("Invalid code", {
+    //   status: 401,
+    //   headers: {"Content-Type": "application/json"},
+    // });
   }
 };

--- a/src/stories/App.stories.tsx
+++ b/src/stories/App.stories.tsx
@@ -32,9 +32,19 @@ const mockUser: User = {
 const MockUserProvider: React.FC<UserProviderProps> = ({children}) => {
   const [user, setUser] = React.useState<User>(mockUser);
   const [isLoggedIn, setIsLoggedIn] = React.useState<boolean>(true);
+  const [currentTab, setCurrentTab] = React.useState<string>("home");
 
   return (
-    <UserContext.Provider value={{user, setUser, isLoggedIn, setIsLoggedIn}}>
+    <UserContext.Provider
+      value={{
+        user,
+        setUser,
+        isLoggedIn,
+        setIsLoggedIn,
+        currentTab,
+        setCurrentTab,
+      }}
+    >
       {children}
     </UserContext.Provider>
   );

--- a/src/stories/Home.stories.tsx
+++ b/src/stories/Home.stories.tsx
@@ -32,11 +32,21 @@ const mockUser: User = {
 const MockUserProvider: React.FC<UserProviderProps> = ({children}) => {
   const [user, setUser] = React.useState<User>(mockUser);
   const [isLoggedIn, setIsLoggedIn] = React.useState<boolean>(true);
+  const [currentTab, setCurrentTab] = React.useState<string>("home");
 
   console.log("Rendering MockUserProvider with user:", user);
 
   return (
-    <UserContext.Provider value={{user, setUser, isLoggedIn, setIsLoggedIn}}>
+    <UserContext.Provider
+      value={{
+        user,
+        setUser,
+        isLoggedIn,
+        setIsLoggedIn,
+        currentTab,
+        setCurrentTab,
+      }}
+    >
       {children}
     </UserContext.Provider>
   );

--- a/src/utils/BackendError.tsx
+++ b/src/utils/BackendError.tsx
@@ -17,17 +17,22 @@ const BackendError: React.FC<BackendErrorProps> = ({
   const {setCurrentTab} = useUserContext();
 
   useEffect(() => {
-    // Perform redirect based on specific error codes
+    // Perform redirect based on specific error codes after a 3-second delay
     if (errorCode === 401 || errorCode === 403) {
-      onRedirect();
-      setCurrentTab("home");
+      const timer = setTimeout(() => {
+        onRedirect();
+        setCurrentTab("home");
+      }, 3000);
+      return () => clearTimeout(timer); // Clear the timer if the component unmounts
     }
   }, [errorCode, onRedirect, setCurrentTab]);
 
   return (
     <div className='fixed top-0 left-0 right-0 bg-red-500 text-white p-4 z-50'>
       <div className='container mx-auto flex justify-between items-center'>
-        <span>{message}</span>
+        <span>
+          {message} (Error Code: {errorCode})
+        </span>
         <button onClick={onClose} className='text-xl font-bold'>
           &times;
         </button>

--- a/src/utils/BackendError.tsx
+++ b/src/utils/BackendError.tsx
@@ -7,7 +7,7 @@ interface BackendErrorProps {
 
 const BackendError: React.FC<BackendErrorProps> = ({message, onClose}) => {
   return (
-    <div className='fixed top-0 left-0 right-0 bg-red-500 text-white p-4'>
+    <div className='fixed top-0 left-0 right-0 bg-red-500 text-white p-4 z-50'>
       <div className='container mx-auto flex justify-between items-center'>
         <span>{message}</span>
         <button onClick={onClose} className='text-xl font-bold'>

--- a/src/utils/BackendError.tsx
+++ b/src/utils/BackendError.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+interface BackendErrorProps {
+  message: string;
+  onClose: () => void;
+}
+
+const BackendError: React.FC<BackendErrorProps> = ({message, onClose}) => {
+  return (
+    <div className='fixed top-0 left-0 right-0 bg-red-500 text-white p-4'>
+      <div className='container mx-auto flex justify-between items-center'>
+        <span>{message}</span>
+        <button onClick={onClose} className='text-xl font-bold'>
+          &times;
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default BackendError;

--- a/src/utils/BackendError.tsx
+++ b/src/utils/BackendError.tsx
@@ -5,6 +5,7 @@ interface BackendErrorProps {
   errorCode: number;
   onClose: () => void;
   onRedirect: () => void;
+  setCurrentTab: (tab: string) => void; // New prop for setting the current tab
 }
 
 const BackendError: React.FC<BackendErrorProps> = ({
@@ -12,12 +13,20 @@ const BackendError: React.FC<BackendErrorProps> = ({
   errorCode,
   onClose,
   onRedirect,
+  setCurrentTab,
 }) => {
   useEffect(() => {
-    if (errorCode === 555) {
+    // Perform redirect based on specific error codes
+    if (errorCode === 401 || errorCode === 403) {
+      // Example error codes
       onRedirect();
     }
   }, [errorCode, onRedirect]);
+
+  // Redirect to home tab when BackendError is rendered
+  useEffect(() => {
+    setCurrentTab("home");
+  }, [setCurrentTab]);
 
   return (
     <div className='fixed top-0 left-0 right-0 bg-red-500 text-white p-4 z-50'>

--- a/src/utils/BackendError.tsx
+++ b/src/utils/BackendError.tsx
@@ -1,11 +1,24 @@
-import React from "react";
+import React, {useEffect} from "react";
 
 interface BackendErrorProps {
   message: string;
+  errorCode: number;
   onClose: () => void;
+  onRedirect: () => void;
 }
 
-const BackendError: React.FC<BackendErrorProps> = ({message, onClose}) => {
+const BackendError: React.FC<BackendErrorProps> = ({
+  message,
+  errorCode,
+  onClose,
+  onRedirect,
+}) => {
+  useEffect(() => {
+    if (errorCode === 555) {
+      onRedirect();
+    }
+  }, [errorCode, onRedirect]);
+
   return (
     <div className='fixed top-0 left-0 right-0 bg-red-500 text-white p-4 z-50'>
       <div className='container mx-auto flex justify-between items-center'>

--- a/src/utils/BackendError.tsx
+++ b/src/utils/BackendError.tsx
@@ -1,11 +1,11 @@
 import React, {useEffect} from "react";
+import {useUserContext} from "../utils/utils";
 
 interface BackendErrorProps {
   message: string;
   errorCode: number;
   onClose: () => void;
   onRedirect: () => void;
-  setCurrentTab: (tab: string) => void; // New prop for setting the current tab
 }
 
 const BackendError: React.FC<BackendErrorProps> = ({
@@ -13,20 +13,16 @@ const BackendError: React.FC<BackendErrorProps> = ({
   errorCode,
   onClose,
   onRedirect,
-  setCurrentTab,
 }) => {
+  const {setCurrentTab} = useUserContext();
+
   useEffect(() => {
     // Perform redirect based on specific error codes
     if (errorCode === 401 || errorCode === 403) {
-      // Example error codes
       onRedirect();
+      setCurrentTab("home");
     }
-  }, [errorCode, onRedirect]);
-
-  // Redirect to home tab when BackendError is rendered
-  useEffect(() => {
-    setCurrentTab("home");
-  }, [setCurrentTab]);
+  }, [errorCode, onRedirect, setCurrentTab]);
 
   return (
     <div className='fixed top-0 left-0 right-0 bg-red-500 text-white p-4 z-50'>

--- a/src/utils/BackendError.tsx
+++ b/src/utils/BackendError.tsx
@@ -18,7 +18,7 @@ const BackendError: React.FC<BackendErrorProps> = ({
 
   useEffect(() => {
     // Perform redirect based on specific error codes after a 3-second delay
-    if (errorCode === 401 || errorCode === 403) {
+    if (errorCode === 409) {
       const timer = setTimeout(() => {
         onRedirect();
         setCurrentTab("home");

--- a/src/utils/api/loginHandler.ts
+++ b/src/utils/api/loginHandler.ts
@@ -1,3 +1,4 @@
+// loginHandler.tsx
 interface LoginHandlerProps {
   phone: string;
   pinString: string;

--- a/src/utils/api/loginHandler.ts
+++ b/src/utils/api/loginHandler.ts
@@ -1,4 +1,3 @@
-// loginHandler.tsx
 interface LoginHandlerProps {
   phone: string;
   pinString: string;
@@ -29,7 +28,7 @@ export const loginHandler = async ({
     if (!response.ok) {
       const errorMessage = await response.text();
       console.error("Error message:", errorMessage);
-      throw new Error(errorMessage);
+      throw {message: errorMessage, status: response.status};
     }
 
     const responseData: {[key: string]: number} = await response.json();
@@ -37,6 +36,6 @@ export const loginHandler = async ({
     return responseData;
   } catch (error) {
     console.error("Error verifying code:", error);
-    throw new Error("Error verifying code: " + error);
+    throw error;
   }
 };

--- a/src/utils/api/loginHandler.ts
+++ b/src/utils/api/loginHandler.ts
@@ -1,3 +1,7 @@
+interface CustomError extends Error {
+  status?: number;
+}
+
 interface LoginHandlerProps {
   phone: string;
   pinString: string;
@@ -28,7 +32,9 @@ export const loginHandler = async ({
     if (!response.ok) {
       const errorMessage = await response.text();
       console.error("Error message:", errorMessage);
-      throw {message: errorMessage, status: response.status};
+      const error: CustomError = new Error(errorMessage);
+      error.status = response.status;
+      throw error;
     }
 
     const responseData: {[key: string]: number} = await response.json();


### PR DESCRIPTION
**This first PR handles only 409 for login endpoint**
-> If we merge it the approach will be extended to more codes and more API calls

When there is an error the backend closes the session but the user is still in the app. The front end did not notify the user about the errors and there is unclear information about what is happening.

- [x] add `currentTab` to user context 
- [x] use user context to switch tab
- [x] create a new component to handle backend errors : `BackendError` When an API call is done, the component will be triggered in the case of an error
- [x] Test the component with login endpoint
- [x] support 409 in  `BackendError` and in the mock for easy testing in dev and prod

## Custom error interface
```
interface CustomError extends Error {
  status?: number;
}
```

The `CustomError` interface extends the built-in Error interface in TypeScript to include an optional status property. 

## Catching the error

state declaration uses _useState_ hook. It can hold an object with a _message_ and an _errorCode_
`const [error, setError] = useState<{ message: string; errorCode: number } | null>(null);
`

```
  try {
    const response = await fetch(`${backendUrl}/send-code`, {
.......
    });
    if (!response.ok) {
      const errorMessage = await response.text();
      throw new Error(errorMessage);
    }
```

Catch Block: If an error occurs during the fetch the setError function is called to update the error state with a message and an error code.


## Rendering the error
```
{error && (
  <BackendError
    message={error.message}
    errorCode={error.errorCode}
    onClose={() => setError(null)}
    onRedirect={() => setIsPhoneSubmitted(false)}
  />
)}
```
The BackendError component is rendered if the error state is not null.
