### PR TITLE
Danielgomeza1406/cha 512 fix agreesale modal to work when closed

### DIFF
--- a/src/components/ChatTable.tsx
+++ b/src/components/ChatTable.tsx
@@ -46,6 +46,7 @@ const ChatTable: React.FC<{backendUrl: string}> = ({backendUrl}) => {
   const handleHideSuccess = () => {
     setShowSuccess(false);
     handleHideAgreeSale();
+    setSelectedValues([]); // Clear selected values when success modal is closed
   };
 
   const handleLoginSuccess = useCallback(() => {
@@ -110,6 +111,7 @@ const ChatTable: React.FC<{backendUrl: string}> = ({backendUrl}) => {
                 alignSelf: "center",
               }}
               onClick={handleShowAgreeSale}
+              disabled={selectedValues.length === 0}
             >
               Sell
             </Button>

--- a/src/components/ChatTable.tsx
+++ b/src/components/ChatTable.tsx
@@ -90,53 +90,52 @@ const ChatTable: React.FC<{backendUrl: string}> = ({backendUrl}) => {
         </Cell>
       ))}
       {user?.chatsToSellUnfolded && user.chatsToSellUnfolded?.length > 0 && (
-        <table className='mt-5 w-full text-center'>
-          <tbody>
-            <tr>
-              <td colSpan={2}>
-                <strong> Total Value: {totalValue} $WORD </strong>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <>
+          <table className='mt-5 w-full text-center'>
+            <tbody>
+              <tr>
+                <td colSpan={2}>
+                  <strong> Total Value: {totalValue} $WORD </strong>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div className='text-center '>
+            <Button
+              size='m'
+              className='text-white'
+              style={{
+                backgroundColor: "--tw-bg-opacity",
+                alignContent: "center",
+                alignSelf: "center",
+              }}
+              onClick={handleShowAgreeSale}
+            >
+              Sell
+            </Button>
+          </div>
+        </>
       )}
-      <div className='text-center '>
-        {user?.chatsToSellUnfolded && user.chatsToSellUnfolded?.length > 0 && (
-          <Button
-            size='m'
-            className='text-white'
-            style={{
-              backgroundColor: "--tw-bg-opacity",
-              alignContent: "center",
-              alignSelf: "center",
-            }}
-            onClick={handleShowAgreeSale}
-          >
-            Sell
-          </Button>
+      <AgreeSale
+        selectedChats={selectedValues.reduce(
+          (acc, id) => {
+            const chat = user.chatsToSellUnfolded?.find(
+              item => String(item.userId) === id,
+            );
+            if (chat) {
+              acc[`(${String(chat.userId)}, '${chat.userName}')`] = chat.words;
+            }
+            return acc;
+          },
+          {} as {[key: string]: number},
         )}
-        <AgreeSale
-          selectedChats={selectedValues.reduce(
-            (acc, id) => {
-              const chat = user.chatsToSellUnfolded?.find(
-                item => String(item.userId) === id,
-              );
-              if (chat) {
-                acc[`(${String(chat.userId)}, '${chat.userName}')`] =
-                  chat.words;
-              }
-              return acc;
-            },
-            {} as {[key: string]: number},
-          )}
-          phoneNumber={phoneNumber}
-          onClose={() => {}}
-          showSuccess={handleShowSuccess}
-          isVisible={showAgreeSale}
-          backendUrl={backendUrl}
-        />
-        {showSuccess && <SuccessModal onClose={handleHideSuccess} />}
-      </div>
+        phoneNumber={phoneNumber}
+        onClose={handleHideAgreeSale}
+        showSuccess={handleShowSuccess}
+        isVisible={showAgreeSale}
+        backendUrl={backendUrl}
+      />
+      {showSuccess && <SuccessModal onClose={handleHideSuccess} />}
     </div>
   );
 };

--- a/src/components/ChatTableInvitations.tsx
+++ b/src/components/ChatTableInvitations.tsx
@@ -12,7 +12,8 @@ const ChatTableInvitations: React.FC<ChatTableInvitationsProps> = ({
 }) => {
   const {user} = useUserContext();
   const [selectedValues, setSelectedValues] = useState<string[]>([]);
-  const [showConfirmSale, setShowConfirmSale] = useState<boolean>(false);
+  const [showConfirmInvitations, setShowConfirmInvitations] =
+    useState<boolean>(false);
 
   const handleSelectionChange = (value: string) => {
     setSelectedValues(prevValues =>
@@ -23,7 +24,7 @@ const ChatTableInvitations: React.FC<ChatTableInvitationsProps> = ({
   };
 
   const handleConfirm = () => {
-    setShowConfirmSale(true);
+    setShowConfirmInvitations(true);
   };
 
   const totalValue = selectedValues.reduce(
@@ -61,9 +62,9 @@ const ChatTableInvitations: React.FC<ChatTableInvitationsProps> = ({
           </Cell>
         ))}
       </form>
-      {pendingChats.length > 0 && (
+      {pendingChats.length > 0 ? (
         <>
-          <table className='mt-5 w-full text-center'>
+          <table className='mt-2 w-full text-center'>
             <tbody>
               <tr>
                 <td colSpan={2}>
@@ -78,10 +79,14 @@ const ChatTableInvitations: React.FC<ChatTableInvitationsProps> = ({
             </Button>
           </div>
         </>
+      ) : (
+        <div className='mt-2 p-4 w-full bg-gray-100 dark:bg-stone-950 rounded-lg shadow'>
+          <p>💬 Here you will find the chats you got invited to sell 💰</p>
+        </div>
       )}
-      {showConfirmSale && (
+      {showConfirmInvitations && (
         <ConfirmInvitations
-          onClose={() => setShowConfirmSale(false)}
+          onClose={() => setShowConfirmInvitations(false)}
           selectedChats={selectedValues.map(id => ({
             userId: user.id,
             chatId: id,

--- a/src/components/ChatTableInvitations.tsx
+++ b/src/components/ChatTableInvitations.tsx
@@ -79,7 +79,12 @@ const ChatTableInvitations: React.FC<ChatTableInvitationsProps> = ({
             </tbody>
           </table>
           <div className='text-center'>
-            <Button mode='filled' size='m' onClick={handleConfirm}>
+            <Button
+              mode='filled'
+              size='m'
+              onClick={handleConfirm}
+              disabled={selectedValues.length === 0}
+            >
               Confirm
             </Button>
           </div>

--- a/src/components/ChatTableInvitations.tsx
+++ b/src/components/ChatTableInvitations.tsx
@@ -27,6 +27,11 @@ const ChatTableInvitations: React.FC<ChatTableInvitationsProps> = ({
     setShowConfirmInvitations(true);
   };
 
+  const handleCloseConfirmInvitations = () => {
+    setShowConfirmInvitations(false);
+    setSelectedValues([]);
+  };
+
   const totalValue = selectedValues.reduce(
     (sum, id) => sum + (user.chats.find(item => item.id === id)?.words || 0),
     0,
@@ -86,7 +91,7 @@ const ChatTableInvitations: React.FC<ChatTableInvitationsProps> = ({
       )}
       {showConfirmInvitations && (
         <ConfirmInvitations
-          onClose={() => setShowConfirmInvitations(false)}
+          onClose={handleCloseConfirmInvitations}
           selectedChats={selectedValues.map(id => ({
             userId: user.id,
             chatId: id,

--- a/src/components/ChatTableInvitations.tsx
+++ b/src/components/ChatTableInvitations.tsx
@@ -57,7 +57,7 @@ const ChatTableInvitations: React.FC<ChatTableInvitationsProps> = ({
             }
             multiline
           >
-            <strong>{item.words} $WORD </strong> - Chat with {item.lead.name}
+            <strong>{item.words} $WORD </strong> - {item.lead.name}
           </Cell>
         ))}
       </form>

--- a/src/components/ChatTableSummary.tsx
+++ b/src/components/ChatTableSummary.tsx
@@ -74,19 +74,19 @@ const ChatTableSummary: React.FC = () => {
         chatStatus.sold,
         "Sold Chats",
         "✅",
-        "Here you will find all the chats that you have sold.",
+        "Here, you can track which conversations are generating rewards.",
       )}
       {renderChatStatus(
         chatStatus.pending,
         "Pending Chats",
         "⏳",
-        "Here you will find all the chats that are pending approval.",
+        "These are your chats that have been submitted for sale but not yet accepted.",
       )}
       {renderChatStatus(
         chatStatus.declined,
         "Declined Chats",
         "❌",
-        "Here you will find all the chats that have been declined.",
+        "Find chats here that were not approved for sale.",
       )}
     </div>
   );

--- a/src/components/ChatTableSummary.tsx
+++ b/src/components/ChatTableSummary.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useEffect} from "react";
 import {useUserContext} from "../utils/utils";
-import {Section, Headline, Banner} from "@telegram-apps/telegram-ui";
+import {Accordion} from "@telegram-apps/telegram-ui";
 
 const ChatTableSummary: React.FC = () => {
   const {user} = useUserContext();
@@ -13,6 +13,8 @@ const ChatTableSummary: React.FC = () => {
     pending: [],
     declined: [],
   });
+
+  const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
     const soldChats = user.chats
@@ -44,20 +46,20 @@ const ChatTableSummary: React.FC = () => {
       statusArray.includes(chat.id),
     );
     return (
-      <Section>
-        <Banner>
-          <Headline weight='3'>
-            {emoji} {statusTitle}
-          </Headline>
-        </Banner>
-        <div className='p-2 ml-4'>
-          <ul>
-            {filteredChats.map(chat => (
-              <li key={chat.id}>Chat with {chat.name}</li>
-            ))}
-          </ul>
-        </div>
-      </Section>
+      <Accordion expanded={expanded} onChange={setExpanded}>
+        <Accordion.Summary>
+          {emoji} {statusTitle}
+        </Accordion.Summary>
+        <Accordion.Content>
+          <div className='p-8 ml-2'>
+            <ul>
+              {filteredChats.map(chat => (
+                <li key={chat.id}>Chat with {chat.lead.name}</li>
+              ))}
+            </ul>
+          </div>
+        </Accordion.Content>
+      </Accordion>
     );
   };
 

--- a/src/components/ChatTableSummary.tsx
+++ b/src/components/ChatTableSummary.tsx
@@ -41,22 +41,27 @@ const ChatTableSummary: React.FC = () => {
     statusArray: string[],
     statusTitle: string,
     emoji: string,
+    description: string,
   ) => {
     const filteredChats = user.chats.filter(chat =>
       statusArray.includes(chat.id),
     );
     return (
       <Accordion expanded={expanded} onChange={setExpanded}>
-        <Accordion.Summary>
+        <Accordion.Summary className='border-2 border-gray-100 dark:border-stone-950'>
           {emoji} {statusTitle}
         </Accordion.Summary>
         <Accordion.Content>
-          <div className='p-8 ml-2'>
-            <ul>
-              {filteredChats.map(chat => (
-                <li key={chat.id}>Chat with {chat.lead.name}</li>
-              ))}
-            </ul>
+          <div className='p-4 bg-gray-100 dark:bg-stone-950'>
+            {filteredChats.length === 0 ? (
+              <p>{description}</p>
+            ) : (
+              <ul>
+                {filteredChats.map(chat => (
+                  <li key={chat.id}>Chat with {chat.lead.name}</li>
+                ))}
+              </ul>
+            )}
           </div>
         </Accordion.Content>
       </Accordion>
@@ -64,10 +69,25 @@ const ChatTableSummary: React.FC = () => {
   };
 
   return (
-    <div className='text-left p-2 mb-20'>
-      {renderChatStatus(chatStatus.sold, "Sold Chats", "✅")}
-      {renderChatStatus(chatStatus.pending, "Pending Chats", "⏳")}
-      {renderChatStatus(chatStatus.declined, "Declined Chats", "❌")}
+    <div className='text-left mb-20'>
+      {renderChatStatus(
+        chatStatus.sold,
+        "Sold Chats",
+        "✅",
+        "Here you will find all the chats that you have sold.",
+      )}
+      {renderChatStatus(
+        chatStatus.pending,
+        "Pending Chats",
+        "⏳",
+        "Here you will find all the chats that are pending approval.",
+      )}
+      {renderChatStatus(
+        chatStatus.declined,
+        "Declined Chats",
+        "❌",
+        "Here you will find all the chats that have been declined.",
+      )}
     </div>
   );
 };

--- a/src/components/ChatTableSummary.tsx
+++ b/src/components/ChatTableSummary.tsx
@@ -53,7 +53,7 @@ const ChatTableSummary: React.FC = () => {
         <div className='p-2 ml-4'>
           <ul>
             {filteredChats.map(chat => (
-              <li key={chat.id}>{chat.name}</li>
+              <li key={chat.id}>Chat with {chat.name}</li>
             ))}
           </ul>
         </div>

--- a/src/components/Chats.tsx
+++ b/src/components/Chats.tsx
@@ -62,7 +62,7 @@ const Chats: React.FC<{backendUrl: string}> = ({backendUrl}) => {
             mode={activeTab === "summary" ? "elevated" : "mono"}
             onClick={() => handleTabClick("summary")}
           >
-            My Summary 📝
+            My summary 📝
           </Chip>
         </List>
       </div>

--- a/src/components/Chats.tsx
+++ b/src/components/Chats.tsx
@@ -38,7 +38,7 @@ const Chats: React.FC<{backendUrl: string}> = ({backendUrl}) => {
 
   return (
     <>
-      <div className='overflow-x-auto'>
+      <div className='overflow-x-auto mb-2'>
         <List
           className='inline-flex rounded-lg shadow space-x-4 px-2 pt-2'
           style={{background: "var(--tgui--secondary_bg_color)"}}

--- a/src/components/Modals/AgreeSale.tsx
+++ b/src/components/Modals/AgreeSale.tsx
@@ -27,7 +27,7 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
   backendUrl,
 }) => {
   const {setUser} = useUserContext();
-  const defautlMessage = `Hey, I checked this ChatPay app and we can make some money by selling our chat history! The chat will be anonymized 🥷: no names, no phone numbers or any personal data. Follow the link:`;
+  const defautlMessage = `Hey, I checked this ChatPay app and we can make some money by selling our chat history! The chat will be anonymized 🥷: no names, no phone numbers, or any personal data. Follow the link:`;
   const [isChecked, setIsChecked] = useState(false);
   const [message, setMessage] = useState(defautlMessage);
   const [isSending, setIsSending] = useState(false);
@@ -137,7 +137,7 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
             </div>
           </div>
           <FlowbiteTextarea
-            label='The invitation for your friend'
+            label='Personalize the invitation'
             placeholder='Enter your message here...'
             value={message}
             onChange={handleMessageChange}
@@ -147,7 +147,6 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
               mode='filled'
               size='s'
               disabled={!isChecked || isSending}
-              className='absolute bottom-2.5 right-2.5'
               onClick={handleSend}
             >
               {isSending ? <Spinner size='s' /> : "Send"}

--- a/src/components/Modals/AgreeSale.tsx
+++ b/src/components/Modals/AgreeSale.tsx
@@ -109,8 +109,14 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
   );
 
   return isVisible ? (
-    <div className='fixed inset-0 w-full h-full bg-black bg-opacity-80 flex justify-center items-center z-50'>
-      <div className='text-center w-10/12 max-w-md'>
+    <div
+      className='fixed inset-0 w-full h-full bg-black bg-opacity-80 flex justify-center items-center z-50'
+      onClick={onClose}
+    >
+      <div
+        className='text-center w-10/12 max-w-md'
+        onClick={e => e.stopPropagation()}
+      >
         <Placeholder
           style={{
             background: "var(--tgui--bg_color)",
@@ -120,12 +126,17 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
         >
           <div className='p-4'>
             <Placeholder
-              description={`Do you confirm to sell the ${selectedChatsCount} selected chats for ${totalAmount} $WORD? 
-          Your friends will receive the following invitation to sell from our app:`}
+              description={`Do you confirm to sell the ${selectedChatsCount} selected ${selectedChatsCount < 2 ? "chat" : "chats"} for ${totalAmount} $WORD?`}
               header='Please confirm'
               style={{padding: 0}}
             />
-            <div className='w-full'>
+            <div className='w-full py-4'>
+              <Textarea
+                label='Personalize the invitation'
+                placeholder='Enter your message here...'
+                value={message}
+                onChange={handleMessageChange}
+              />
               <div className='py-5 text-left'>
                 <div className='flex items-center'>
                   <Checkbox
@@ -144,22 +155,21 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
                   </span>
                 </div>
               </div>
-              <Textarea
-                label='Personalize the invitation'
-                placeholder='Enter your message here...'
-                value={message}
-                onChange={handleMessageChange}
-              />
-              <div className='flex gap-y-2 flex-col py-5 items-center'>
+              <div className='flex gap-y-2 flex-col py-2 items-center'>
                 <Button
                   mode='filled'
-                  size='s'
+                  size='m'
                   disabled={!isChecked || isSending}
                   onClick={handleSend}
                 >
                   {isSending ? <Spinner size='s' /> : "Send"}
                 </Button>
-                <Button mode='outline' size='m' onClick={onClose}>
+                <Button
+                  className='text-gray-400'
+                  mode='outline'
+                  size='m'
+                  onClick={onClose}
+                >
                   Close
                 </Button>
               </div>

--- a/src/components/Modals/AgreeSale.tsx
+++ b/src/components/Modals/AgreeSale.tsx
@@ -1,6 +1,5 @@
 import React, {useState} from "react";
 import {
-  Modal,
   Button,
   Placeholder,
   Checkbox,
@@ -8,7 +7,8 @@ import {
 } from "@telegram-apps/telegram-ui";
 import {sendMessageHandler} from "../../utils/api/sendMessageHandler";
 import {useUserContext} from "../../utils/utils";
-import FlowbiteTextarea from "../TextArea";
+import Textarea from "../TextArea";
+
 type AgreeSaleProps = {
   selectedChats: {[key: string]: number};
   phoneNumber: string;
@@ -108,54 +108,67 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
     0,
   );
 
-  return (
-    <Modal
-      open={isVisible}
-      onOpenChange={onClose}
-      header={<Modal.Header></Modal.Header>}
-    >
-      <div className='p-5'>
+  return isVisible ? (
+    <div className='fixed inset-0 w-full h-full bg-black bg-opacity-80 flex justify-center items-center z-50'>
+      <div className='text-center w-10/12 max-w-md'>
         <Placeholder
-          description={`Do you confirm to sell the ${selectedChatsCount} selected chats for ${totalAmount} $WORD? 
+          style={{
+            background: "var(--tgui--bg_color)",
+            borderRadius: "1rem",
+            padding: 0,
+          }}
+        >
+          <div className='p-4'>
+            <Placeholder
+              description={`Do you confirm to sell the ${selectedChatsCount} selected chats for ${totalAmount} $WORD? 
           Your friends will receive the following invitation to sell from our app:`}
-          header='Please confirm'
-        />
-        <div className='w-full'>
-          <div className='py-5 text-left'>
-            <div className='flex items-center'>
-              <Checkbox checked={isChecked} onChange={handleCheckboxChange} />
-              <span className='ml-2'>
-                I agree to the{" "}
-                <a
-                  href='https://www.chatpay.app/user-agreement.pdf'
-                  target='_blank'
-                  rel='noopener noreferrer'
+              header='Please confirm'
+              style={{padding: 0}}
+            />
+            <div className='w-full'>
+              <div className='py-5 text-left'>
+                <div className='flex items-center'>
+                  <Checkbox
+                    checked={isChecked}
+                    onChange={handleCheckboxChange}
+                  />
+                  <span className='ml-2'>
+                    I agree to the{" "}
+                    <a
+                      href='https://www.chatpay.app/user-agreement.pdf'
+                      target='_blank'
+                      rel='noopener noreferrer'
+                    >
+                      terms and conditions
+                    </a>
+                  </span>
+                </div>
+              </div>
+              <Textarea
+                label='Personalize the invitation'
+                placeholder='Enter your message here...'
+                value={message}
+                onChange={handleMessageChange}
+              />
+              <div className='flex gap-y-2 flex-col py-5 items-center'>
+                <Button
+                  mode='filled'
+                  size='s'
+                  disabled={!isChecked || isSending}
+                  onClick={handleSend}
                 >
-                  terms and conditions
-                </a>
-              </span>
+                  {isSending ? <Spinner size='s' /> : "Send"}
+                </Button>
+                <Button mode='outline' size='m' onClick={onClose}>
+                  Close
+                </Button>
+              </div>
             </div>
           </div>
-          <FlowbiteTextarea
-            label='Personalize the invitation'
-            placeholder='Enter your message here...'
-            value={message}
-            onChange={handleMessageChange}
-          />
-          <div className='py-5 text-center relative'>
-            <Button
-              mode='filled'
-              size='s'
-              disabled={!isChecked || isSending}
-              onClick={handleSend}
-            >
-              {isSending ? <Spinner size='s' /> : "Send"}
-            </Button>
-          </div>
-        </div>
+        </Placeholder>
       </div>
-    </Modal>
-  );
+    </div>
+  ) : null;
 };
 
 export default AgreeSale;

--- a/src/components/Modals/AgreeSale.tsx
+++ b/src/components/Modals/AgreeSale.tsx
@@ -3,13 +3,12 @@ import {
   Modal,
   Button,
   Placeholder,
-  Textarea,
   Checkbox,
   Spinner,
 } from "@telegram-apps/telegram-ui";
 import {sendMessageHandler} from "../../utils/api/sendMessageHandler";
 import {useUserContext} from "../../utils/utils";
-
+import FlowbiteTextarea from "../TextArea";
 type AgreeSaleProps = {
   selectedChats: {[key: string]: number};
   phoneNumber: string;
@@ -28,8 +27,7 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
   backendUrl,
 }) => {
   const {setUser} = useUserContext();
-  const defautlMessage = `Hey, I checked this ChatPay app and we can make some money by selling our chat history! The chat will be anonymized 🥷: no names, no phone numbers or any personal data. It's not for ads 🙅, only to train AI models! So pretty cool 🦾
-  I already agreed: the chat will be sold only if all participants agree 🙋‍♀️. Follow the link:`;
+  const defautlMessage = `Hey, I checked this ChatPay app and we can make some money by selling our chat history! The chat will be anonymized 🥷: no names, no phone numbers or any personal data. Follow the link:`;
   const [isChecked, setIsChecked] = useState(false);
   const [message, setMessage] = useState(defautlMessage);
   const [isSending, setIsSending] = useState(false);
@@ -38,7 +36,7 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
     setIsChecked(!isChecked);
   };
 
-  const handleMessageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleMessageChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setMessage(e.target.value);
   };
 
@@ -138,12 +136,11 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
               </span>
             </div>
           </div>
-          <Textarea
-            header='The invitation for your friend'
-            placeholder='I am usual textarea'
+          <FlowbiteTextarea
+            label='The invitation for your friend'
+            placeholder='Enter your message here...'
             value={message}
             onChange={handleMessageChange}
-            style={{width: "100%", height: "220px"}}
           />
           <div className='py-5 text-center relative'>
             <Button

--- a/src/components/Modals/AgreeSale.tsx
+++ b/src/components/Modals/AgreeSale.tsx
@@ -94,7 +94,9 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
           chatsToSellUnfolded: updatedChatsToSellUnfolded,
         };
       });
-      showSuccess();
+
+      onClose();
+      setTimeout(showSuccess, 200);
     } catch (error) {
       console.error("Error sending message:", error);
     } finally {

--- a/src/components/Modals/AgreeSale.tsx
+++ b/src/components/Modals/AgreeSale.tsx
@@ -110,7 +110,7 @@ const AgreeSale: React.FC<AgreeSaleProps> = ({
 
   return isVisible ? (
     <div
-      className='fixed inset-0 w-full h-full bg-black bg-opacity-80 flex justify-center items-center z-50'
+      className='fixed inset-0 w-full h-full bg-gray-400 dark:bg-black bg-opacity-80 flex justify-center items-center z-50'
       onClick={onClose}
     >
       <div

--- a/src/components/Modals/ConfirmInvitations.tsx
+++ b/src/components/Modals/ConfirmInvitations.tsx
@@ -56,6 +56,8 @@ const ConfirmInvitation: React.FC<ConfirmInvitationProps> = ({
           chats: updatedChats,
         };
       });
+
+      onClose();
     } catch (error) {
       const customError = error as CustomError;
       if (customError.status) {

--- a/src/components/Modals/ConfirmInvitations.tsx
+++ b/src/components/Modals/ConfirmInvitations.tsx
@@ -76,7 +76,7 @@ const ConfirmInvitation: React.FC<ConfirmInvitationProps> = ({
         >
           <div
             className='text-center w-10/12 max-w-md'
-            onClick={e => e.stopPropagation()} // Prevent closing when clicking inside the modal
+            onClick={e => e.stopPropagation()}
           >
             <Placeholder
               style={{

--- a/src/components/Modals/ConfirmInvitations.tsx
+++ b/src/components/Modals/ConfirmInvitations.tsx
@@ -44,7 +44,7 @@ const ConfirmInvitation: React.FC<ConfirmInvitationProps> = ({
             return {
               ...chat,
               status: response[chat.id],
-              name: `Chat with ${chat.lead.name}`,
+              name: `${chat.lead.name}`,
               agreed_users: updatedAgreedUsers,
             };
           }

--- a/src/components/Modals/ConfirmInvitations.tsx
+++ b/src/components/Modals/ConfirmInvitations.tsx
@@ -71,7 +71,7 @@ const ConfirmInvitation: React.FC<ConfirmInvitationProps> = ({
     <>
       {showConfirmInvitationModal && (
         <div
-          className='fixed inset-0 w-full h-full bg-black bg-opacity-80 flex justify-center items-center z-50'
+          className='fixed inset-0 w-full h-full bg-gray-400 dark:bg-black bg-opacity-80 flex justify-center items-center z-50'
           onClick={onClose}
         >
           <div

--- a/src/components/Modals/ConfirmInvitations.tsx
+++ b/src/components/Modals/ConfirmInvitations.tsx
@@ -70,8 +70,14 @@ const ConfirmInvitation: React.FC<ConfirmInvitationProps> = ({
   return (
     <>
       {showConfirmInvitationModal && (
-        <div className='fixed inset-0 w-full h-full bg-black bg-opacity-80 flex justify-center items-center z-50'>
-          <div className='text-center w-10/12 max-w-md'>
+        <div
+          className='fixed inset-0 w-full h-full bg-black bg-opacity-80 flex justify-center items-center z-50'
+          onClick={onClose}
+        >
+          <div
+            className='text-center w-10/12 max-w-md'
+            onClick={e => e.stopPropagation()} // Prevent closing when clicking inside the modal
+          >
             <Placeholder
               style={{
                 background: "var(--tgui--bg_color)",
@@ -79,15 +85,16 @@ const ConfirmInvitation: React.FC<ConfirmInvitationProps> = ({
                 padding: 0,
               }}
             >
-              <div className=''>
+              <div className='m-2'>
                 <Placeholder
                   description={`Do you confirm to sell ${selectedChats.length} selected ${selectedChats.length < 2 ? "chat" : "chats"} for ${word} points?`}
                   header='Confirm Sale'
+                  style={{padding: "1rem"}}
                 />
                 <div className='p-2 text-center'>
                   {error && <div className='text-red-500 mb-4'>{error}</div>}{" "}
                   {/* Display error message */}
-                  <div className='flex items-center justify-center mb-12'>
+                  <div className='flex items-center justify-center mb-4'>
                     <Checkbox
                       checked={agreed}
                       onChange={() => setAgreed(!agreed)}
@@ -113,7 +120,12 @@ const ConfirmInvitation: React.FC<ConfirmInvitationProps> = ({
                   </Button>
                 </div>
                 <div className='text-center pb-8'>
-                  <Button mode='outline' size='m' onClick={onClose}>
+                  <Button
+                    className='text-gray-400'
+                    mode='outline'
+                    size='m'
+                    onClick={onClose}
+                  >
                     Close
                   </Button>
                 </div>

--- a/src/components/Modals/OnboardUserB.tsx
+++ b/src/components/Modals/OnboardUserB.tsx
@@ -7,7 +7,10 @@ interface OnboardUserBProps {
 
 const OnboardUserB: React.FC<OnboardUserBProps> = ({onClose}) => {
   return (
-    <div className='fixed inset-0 w-full h-full bg-gray-400 dark:bg-black bg-opacity-80 flex justify-center items-center z-50'>
+    <div
+      className='fixed inset-0 w-full h-full bg-gray-400 dark:bg-black bg-opacity-80 flex justify-center items-center z-50'
+      onClick={onClose}
+    >
       <div className='text-center w-4/5 max-w-md'>
         <Placeholder
           style={{

--- a/src/components/Modals/OnboardUserB.tsx
+++ b/src/components/Modals/OnboardUserB.tsx
@@ -7,7 +7,7 @@ interface OnboardUserBProps {
 
 const OnboardUserB: React.FC<OnboardUserBProps> = ({onClose}) => {
   return (
-    <div className='fixed inset-0 w-full h-full bg-black bg-opacity-80 flex justify-center items-center z-50'>
+    <div className='fixed inset-0 w-full h-full bg-gray-400 dark:bg-black bg-opacity-80 flex justify-center items-center z-50'>
       <div className='text-center w-4/5 max-w-md'>
         <Placeholder
           style={{

--- a/src/components/Modals/SuccessModal.tsx
+++ b/src/components/Modals/SuccessModal.tsx
@@ -7,27 +7,18 @@ type SuccessModalProps = {
 
 const SuccessModal: React.FC<SuccessModalProps> = ({onClose}) => {
   return (
-    <Modal
-      header={<Modal.Header>Success</Modal.Header>}
-      open={true}
-      onOpenChange={onClose}
-    >
+    <Modal open={true} onOpenChange={onClose}>
       <Placeholder
-        description='Your message has been sent successfully.'
+        description='Your message has been sent successfully. Keep track of your chat in my summary'
         header='Success'
       />
       <div
         style={{
-          padding: "20px 0",
+          padding: "0 0 20px 0",
           textAlign: "center",
         }}
       >
-        <Button
-          mode='filled'
-          size='s'
-          style={{marginTop: "20px"}}
-          onClick={onClose}
-        >
+        <Button mode='filled' size='s' onClick={onClose}>
           Close
         </Button>
       </div>

--- a/src/components/PhoneNumberInput.tsx
+++ b/src/components/PhoneNumberInput.tsx
@@ -27,7 +27,7 @@ const PhoneNumberInput: React.FC<PhoneNumberInputProps> = ({
           </svg>
         </span>
         <input
-          type='number'
+          type='tel'
           id='floating-phone-number'
           className='block py-2.5 ps-6 pe-0 w-full text-sm text-gray-900 bg-transparent border-0 border-b-2 border-gray-300 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer'
           pattern='[0-9]{3}-[0-9]{3}-[0-9]{4}'

--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -17,13 +17,13 @@ const Textarea: React.FC<TextareaProps> = ({
     <div className='max-w-xs mx-auto'>
       <label
         htmlFor='flowbite-textarea'
-        className='block mb-2 text-sm font-medium text-gray-900 dark:text-white'
+        className='block mb-2 text-sm font-medium text-zinc-500 dark:text-zinc-400'
       >
         {label}
       </label>
       <textarea
         id='flowbite-textarea'
-        className='block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500'
+        className='block p-4 w-full h-60 text-base text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-neutral-700 dark:border-neutral-600 dark:placeholder-neutral-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500'
         placeholder={placeholder}
         value={value}
         onChange={onChange}

--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -23,7 +23,7 @@ const Textarea: React.FC<TextareaProps> = ({
       </label>
       <textarea
         id='flowbite-textarea'
-        className='block p-4 w-full h-60 text-base text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-neutral-700 dark:border-neutral-600 dark:placeholder-neutral-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500'
+        className='block p-4 w-full h-48 text-base text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-neutral-700 dark:border-neutral-600 dark:placeholder-neutral-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500'
         placeholder={placeholder}
         value={value}
         onChange={onChange}

--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+interface TextareaProps {
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  placeholder: string;
+  label: string;
+}
+
+const Textarea: React.FC<TextareaProps> = ({
+  value,
+  onChange,
+  placeholder,
+  label,
+}) => {
+  return (
+    <div className='max-w-xs mx-auto'>
+      <label
+        htmlFor='flowbite-textarea'
+        className='block mb-2 text-sm font-medium text-gray-900 dark:text-white'
+      >
+        {label}
+      </label>
+      <textarea
+        id='flowbite-textarea'
+        className='block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500'
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+      />
+    </div>
+  );
+};
+
+export default Textarea;


### PR DESCRIPTION
- [x] Replace the text area with a better and more functional option.
- [x] Fix the success modal to avoid showing "success" two times and add more information to it.
- [x] Convert the categories in my summary to accordions and display a message when they're empty with a small explanation.
- [x] Fix the AgreeSale modal to work again when closed.
- [x] Add functionality for the modals to close when tapping outside them.
- [x] Improve the UI of the modals.
- [x] Have a lighter background for the modals when in light mode.
- [x] Locked the buttons in my chats and my invitations if there are no chats selected.
- [ ] Keep the phone number in the input even when the user switches between chips.